### PR TITLE
Add deployment permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      deployments: write
     steps:
       - name: Validate version format
         run: |


### PR DESCRIPTION
# Description

This PR updates the release workflow to grant the job explicit deployment permissions for actions that require deployment scopes.

* Added deployments: write to the workflow job permissions.

## Change management

See project labels for change classification and risk.

Change reason?

Please describe the reason for the change here.

Change rollback plan?

If nothing else is specified, the change will be rolled back by reverting the commit.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration