### PR TITLE
Use Type InfinityTime in models, so that Unmarshal can work for strings with or without timestamp

### DIFF
--- a/config/conference_alias_test.go
+++ b/config/conference_alias_test.go
@@ -6,6 +6,7 @@ import (
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
 	"github.com/pexip/go-infinity-sdk/v38/options"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -86,7 +87,7 @@ func TestService_GetConferenceAlias(t *testing.T) {
 		Alias:        "test-alias",
 		Conference:   "/api/admin/configuration/v1/conference/1/",
 		Description:  "Test conference alias",
-		CreationTime: time.Now(),
+		CreationTime: util.InfinityTime{Time: time.Now()},
 	}
 
 	client.On("GetJSON", t.Context(), "configuration/v1/conference_alias/1/", mock.AnythingOfType("*config.ConferenceAlias")).Return(nil).Run(func(args mock.Arguments) {

--- a/config/models.go
+++ b/config/models.go
@@ -1,9 +1,8 @@
 package config
 
 import (
-	"time"
-
 	"github.com/pexip/go-infinity-sdk/v38/options"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 )
 
 // ListOptions contains options for listing resources
@@ -98,12 +97,12 @@ type LocationListResponse struct {
 
 // ConferenceAlias represents a conference alias configuration
 type ConferenceAlias struct {
-	ID           int       `json:"id,omitempty"`
-	Alias        string    `json:"alias"`
-	Conference   string    `json:"conference"`
-	Description  string    `json:"description,omitempty"`
-	CreationTime time.Time `json:"creation_time,omitempty"`
-	ResourceURI  string    `json:"resource_uri,omitempty"`
+	ID           int               `json:"id,omitempty"`
+	Alias        string            `json:"alias"`
+	Conference   string            `json:"conference"`
+	Description  string            `json:"description,omitempty"`
+	CreationTime util.InfinityTime `json:"creation_time,omitempty"`
+	ResourceURI  string            `json:"resource_uri,omitempty"`
 }
 
 // ConferenceAliasCreateRequest represents a request to create a conference alias

--- a/history/alarm_test.go
+++ b/history/alarm_test.go
@@ -8,6 +8,7 @@ import (
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
 	"github.com/pexip/go-infinity-sdk/v38/options"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -36,7 +37,7 @@ func TestService_ListAlarms(t *testing.T) {
 				Level:       "warning",
 				Name:        "capacity_exhausted",
 				Node:        "192.168.1.1",
-				TimeRaised:  &time.Time{},
+				TimeRaised:  &util.InfinityTime{},
 				ResourceURI: "/api/admin/history/v1/alarm/1/",
 			},
 		},
@@ -68,7 +69,7 @@ func TestService_GetAlarm(t *testing.T) {
 		Level:       "critical",
 		Name:        "licenses_exhausted",
 		Node:        "192.168.1.1",
-		TimeRaised:  &time.Time{},
+		TimeRaised:  &util.InfinityTime{},
 		ResourceURI: "/api/admin/history/v1/alarm/1/",
 	}
 

--- a/history/backplane_media_stream_test.go
+++ b/history/backplane_media_stream_test.go
@@ -8,6 +8,7 @@ import (
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
 	"github.com/pexip/go-infinity-sdk/v38/options"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -32,8 +33,8 @@ func TestService_ListBackplaneMediaStreams(t *testing.T) {
 				ID:                1,
 				StreamID:          "stream-123",
 				StreamType:        "video",
-				StartTime:         &time.Time{},
-				EndTime:           &time.Time{},
+				StartTime:         &util.InfinityTime{},
+				EndTime:           &util.InfinityTime{},
 				Node:              "node1.example.com",
 				RxBitrate:         1024,
 				RxCodec:           "H.264",
@@ -77,8 +78,8 @@ func TestService_GetBackplaneMediaStream(t *testing.T) {
 		ID:                1,
 		StreamID:          "stream-456",
 		StreamType:        "audio",
-		StartTime:         &time.Time{},
-		EndTime:           &time.Time{},
+		StartTime:         &util.InfinityTime{},
+		EndTime:           &util.InfinityTime{},
 		Node:              "node2.example.com",
 		RxBitrate:         64,
 		RxCodec:           "Opus",

--- a/history/backplane_test.go
+++ b/history/backplane_test.go
@@ -8,6 +8,7 @@ import (
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
 	"github.com/pexip/go-infinity-sdk/v38/options"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -33,8 +34,8 @@ func TestService_ListBackplanes(t *testing.T) {
 				ConferenceName:       "test-conference",
 				DisconnectReason:     "Normal call clearing",
 				Duration:             &[]int{3600}[0],
-				StartTime:            &time.Time{},
-				EndTime:              &time.Time{},
+				StartTime:            &util.InfinityTime{},
+				EndTime:              &util.InfinityTime{},
 				MediaNode:            "node1.example.com",
 				Protocol:             "INTERNAL",
 				RemoteConferenceName: "remote-conference",
@@ -70,8 +71,8 @@ func TestService_GetBackplane(t *testing.T) {
 		ConferenceName:       "test-conference",
 		DisconnectReason:     "Normal call clearing",
 		Duration:             &[]int{7200}[0],
-		StartTime:            &time.Time{},
-		EndTime:              &time.Time{},
+		StartTime:            &util.InfinityTime{},
+		EndTime:              &util.InfinityTime{},
 		MediaNode:            "node1.example.com",
 		Protocol:             "GMS",
 		RemoteConferenceName: "remote-conference",

--- a/history/models.go
+++ b/history/models.go
@@ -1,9 +1,8 @@
 package history
 
 import (
-	"time"
-
 	"github.com/pexip/go-infinity-sdk/v38/options"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 )
 
 // ListOptions contains options for listing historical records
@@ -11,16 +10,16 @@ type ListOptions = options.TimeFilteredListOptions
 
 // Alarm represents an alarm history record
 type Alarm struct {
-	ID          int        `json:"id"`
-	Details     string     `json:"details"`
-	Identifier  int        `json:"identifier"`
-	Instance    string     `json:"instance"`
-	Level       string     `json:"level"`
-	Name        string     `json:"name"`
-	Node        string     `json:"node"`
-	TimeRaised  *time.Time `json:"time_raised"`
-	TimeLowered *time.Time `json:"time_lowered"`
-	ResourceURI string     `json:"resource_uri"`
+	ID          int                `json:"id"`
+	Details     string             `json:"details"`
+	Identifier  int                `json:"identifier"`
+	Instance    string             `json:"instance"`
+	Level       string             `json:"level"`
+	Name        string             `json:"name"`
+	Node        string             `json:"node"`
+	TimeRaised  *util.InfinityTime `json:"time_raised"`
+	TimeLowered *util.InfinityTime `json:"time_lowered"`
+	ResourceURI string             `json:"resource_uri"`
 }
 
 // AlarmListResponse represents the response from listing alarm history
@@ -37,22 +36,22 @@ type AlarmListResponse struct {
 
 // Backplane represents a backplane history record
 type Backplane struct {
-	ID                   string     `json:"id"`
-	ConferenceName       string     `json:"conference_name"`
-	DisconnectReason     string     `json:"disconnect_reason"`
-	Duration             *int       `json:"duration"`
-	StartTime            *time.Time `json:"start_time"`
-	EndTime              *time.Time `json:"end_time"`
-	MediaNode            string     `json:"media_node"`
-	Protocol             string     `json:"protocol"`
-	ProxyNode            string     `json:"proxy_node"`
-	RemoteConferenceName string     `json:"remote_conference_name"`
-	RemoteMediaNode      string     `json:"remote_media_node"`
-	RemoteNodeName       string     `json:"remote_node_name"`
-	ServiceTag           string     `json:"service_tag"`
-	SystemLocation       string     `json:"system_location"`
-	Type                 string     `json:"type"`
-	ResourceURI          string     `json:"resource_uri"`
+	ID                   string             `json:"id"`
+	ConferenceName       string             `json:"conference_name"`
+	DisconnectReason     string             `json:"disconnect_reason"`
+	Duration             *int               `json:"duration"`
+	StartTime            *util.InfinityTime `json:"start_time"`
+	EndTime              *util.InfinityTime `json:"end_time"`
+	MediaNode            string             `json:"media_node"`
+	Protocol             string             `json:"protocol"`
+	ProxyNode            string             `json:"proxy_node"`
+	RemoteConferenceName string             `json:"remote_conference_name"`
+	RemoteMediaNode      string             `json:"remote_media_node"`
+	RemoteNodeName       string             `json:"remote_node_name"`
+	ServiceTag           string             `json:"service_tag"`
+	SystemLocation       string             `json:"system_location"`
+	Type                 string             `json:"type"`
+	ResourceURI          string             `json:"resource_uri"`
 }
 
 // BackplaneListResponse represents the response from listing backplane history
@@ -69,27 +68,27 @@ type BackplaneListResponse struct {
 
 // BackplaneMediaStream represents a backplane media stream history record
 type BackplaneMediaStream struct {
-	ID                int        `json:"id"`
-	StreamID          string     `json:"stream_id"`
-	StreamType        string     `json:"stream_type"`
-	StartTime         *time.Time `json:"start_time"`
-	EndTime           *time.Time `json:"end_time"`
-	Node              string     `json:"node"`
-	RxBitrate         int        `json:"rx_bitrate"`
-	RxCodec           string     `json:"rx_codec"`
-	RxFPS             float64    `json:"rx_fps"`
-	RxPacketLoss      float64    `json:"rx_packet_loss"`
-	RxPacketsLost     int        `json:"rx_packets_lost"`
-	RxPacketsReceived int        `json:"rx_packets_received"`
-	RxResolution      string     `json:"rx_resolution"`
-	TxBitrate         int        `json:"tx_bitrate"`
-	TxCodec           string     `json:"tx_codec"`
-	TxFPS             float64    `json:"tx_fps"`
-	TxPacketLoss      float64    `json:"tx_packet_loss"`
-	TxPacketsLost     int        `json:"tx_packets_lost"`
-	TxPacketsSent     int        `json:"tx_packets_sent"`
-	TxResolution      string     `json:"tx_resolution"`
-	ResourceURI       string     `json:"resource_uri"`
+	ID                int                `json:"id"`
+	StreamID          string             `json:"stream_id"`
+	StreamType        string             `json:"stream_type"`
+	StartTime         *util.InfinityTime `json:"start_time"`
+	EndTime           *util.InfinityTime `json:"end_time"`
+	Node              string             `json:"node"`
+	RxBitrate         int                `json:"rx_bitrate"`
+	RxCodec           string             `json:"rx_codec"`
+	RxFPS             float64            `json:"rx_fps"`
+	RxPacketLoss      float64            `json:"rx_packet_loss"`
+	RxPacketsLost     int                `json:"rx_packets_lost"`
+	RxPacketsReceived int                `json:"rx_packets_received"`
+	RxResolution      string             `json:"rx_resolution"`
+	TxBitrate         int                `json:"tx_bitrate"`
+	TxCodec           string             `json:"tx_codec"`
+	TxFPS             float64            `json:"tx_fps"`
+	TxPacketLoss      float64            `json:"tx_packet_loss"`
+	TxPacketsLost     int                `json:"tx_packets_lost"`
+	TxPacketsSent     int                `json:"tx_packets_sent"`
+	TxResolution      string             `json:"tx_resolution"`
+	ResourceURI       string             `json:"resource_uri"`
 }
 
 // BackplaneMediaStreamListResponse represents the response from listing backplane media stream history
@@ -106,20 +105,20 @@ type BackplaneMediaStreamListResponse struct {
 
 // ConferenceRecord represents a conference history record
 type ConferenceRecord struct {
-	ID                  int       `json:"id"`
-	Name                string    `json:"name"`
-	ServiceType         string    `json:"service_type"`
-	Tag                 string    `json:"tag"`
-	StartTime           time.Time `json:"start_time"`
-	EndTime             time.Time `json:"end_time"`
-	CreateTime          time.Time `json:"create_time"`
-	DurationSeconds     int       `json:"duration_seconds"`
-	TotalParticipants   int       `json:"total_participants"`
-	MaxConcurrentGuests int       `json:"max_concurrent_guests"`
-	MaxConcurrentHosts  int       `json:"max_concurrent_hosts"`
-	TotalBandwidthKbps  int       `json:"total_bandwidth_kbps"`
-	InstanceType        string    `json:"instance_type"`
-	ResourceURI         string    `json:"resource_uri"`
+	ID                  int               `json:"id"`
+	Name                string            `json:"name"`
+	ServiceType         string            `json:"service_type"`
+	Tag                 string            `json:"tag"`
+	StartTime           util.InfinityTime `json:"start_time"`
+	EndTime             util.InfinityTime `json:"end_time"`
+	CreateTime          util.InfinityTime `json:"create_time"`
+	DurationSeconds     int               `json:"duration_seconds"`
+	TotalParticipants   int               `json:"total_participants"`
+	MaxConcurrentGuests int               `json:"max_concurrent_guests"`
+	MaxConcurrentHosts  int               `json:"max_concurrent_hosts"`
+	TotalBandwidthKbps  int               `json:"total_bandwidth_kbps"`
+	InstanceType        string            `json:"instance_type"`
+	ResourceURI         string            `json:"resource_uri"`
 }
 
 // ConferenceRecordListResponse represents the response from listing conference history
@@ -136,28 +135,28 @@ type ConferenceRecordListResponse struct {
 
 // MediaStream represents a media stream history record
 type MediaStream struct {
-	ID              int       `json:"id"`
-	ParticipantID   int       `json:"participant_id"`
-	Node            string    `json:"node"`
-	StreamType      string    `json:"stream_type"`
-	Direction       string    `json:"direction"`
-	StartTime       time.Time `json:"start_time"`
-	EndTime         time.Time `json:"end_time"`
-	DurationSeconds int       `json:"duration_seconds"`
-	RxPackets       int       `json:"rx_packets"`
-	TxPackets       int       `json:"tx_packets"`
-	RxBytes         int64     `json:"rx_bytes"`
-	TxBytes         int64     `json:"tx_bytes"`
-	RxPacketsLost   int       `json:"rx_packets_lost"`
-	TxPacketsLost   int       `json:"tx_packets_lost"`
-	RxJitter        float64   `json:"rx_jitter"`
-	TxJitter        float64   `json:"tx_jitter"`
-	Codec           string    `json:"codec"`
-	Resolution      string    `json:"resolution"`
-	FrameRate       float64   `json:"frame_rate"`
-	Bitrate         int       `json:"bitrate"`
-	PacketRate      float64   `json:"packet_rate"`
-	ResourceURI     string    `json:"resource_uri"`
+	ID              int               `json:"id"`
+	ParticipantID   int               `json:"participant_id"`
+	Node            string            `json:"node"`
+	StreamType      string            `json:"stream_type"`
+	Direction       string            `json:"direction"`
+	StartTime       util.InfinityTime `json:"start_time"`
+	EndTime         util.InfinityTime `json:"end_time"`
+	DurationSeconds int               `json:"duration_seconds"`
+	RxPackets       int               `json:"rx_packets"`
+	TxPackets       int               `json:"tx_packets"`
+	RxBytes         int64             `json:"rx_bytes"`
+	TxBytes         int64             `json:"tx_bytes"`
+	RxPacketsLost   int               `json:"rx_packets_lost"`
+	TxPacketsLost   int               `json:"tx_packets_lost"`
+	RxJitter        float64           `json:"rx_jitter"`
+	TxJitter        float64           `json:"tx_jitter"`
+	Codec           string            `json:"codec"`
+	Resolution      string            `json:"resolution"`
+	FrameRate       float64           `json:"frame_rate"`
+	Bitrate         int               `json:"bitrate"`
+	PacketRate      float64           `json:"packet_rate"`
+	ResourceURI     string            `json:"resource_uri"`
 }
 
 // MediaStreamListResponse represents the response from listing media stream history
@@ -174,35 +173,35 @@ type MediaStreamListResponse struct {
 
 // Participant represents a participant history record
 type Participant struct {
-	ID               int       `json:"id"`
-	ConferenceID     int       `json:"conference_id"`
-	ConferenceName   string    `json:"conference_name"`
-	LocalAlias       string    `json:"local_alias"`
-	RemoteAlias      string    `json:"remote_alias"`
-	DisplayName      string    `json:"display_name"`
-	Role             string    `json:"role"`
-	ServiceType      string    `json:"service_type"`
-	CallDirection    string    `json:"call_direction"`
-	StartTime        time.Time `json:"start_time"`
-	EndTime          time.Time `json:"end_time"`
-	DurationSeconds  int       `json:"duration_seconds"`
-	DisconnectReason string    `json:"disconnect_reason"`
-	RemoteAddress    string    `json:"remote_address"`
-	RemotePort       int       `json:"remote_port"`
-	SIPCallID        string    `json:"sip_call_id"`
-	Vendor           string    `json:"vendor"`
-	UserAgent        string    `json:"user_agent"`
-	TotalRxPackets   int       `json:"total_rx_packets"`
-	TotalTxPackets   int       `json:"total_tx_packets"`
-	TotalRxBytes     int64     `json:"total_rx_bytes"`
-	TotalTxBytes     int64     `json:"total_tx_bytes"`
-	MediaNode        string    `json:"media_node"`
-	SignalingNode    string    `json:"signaling_node"`
-	Encryption       string    `json:"encryption"`
-	ConversationID   string    `json:"conversation_id"`
-	CallUUID         string    `json:"call_uuid"`
-	ParentID         string    `json:"parent_id"`
-	ResourceURI      string    `json:"resource_uri"`
+	ID               int               `json:"id"`
+	ConferenceID     int               `json:"conference_id"`
+	ConferenceName   string            `json:"conference_name"`
+	LocalAlias       string            `json:"local_alias"`
+	RemoteAlias      string            `json:"remote_alias"`
+	DisplayName      string            `json:"display_name"`
+	Role             string            `json:"role"`
+	ServiceType      string            `json:"service_type"`
+	CallDirection    string            `json:"call_direction"`
+	StartTime        util.InfinityTime `json:"start_time"`
+	EndTime          util.InfinityTime `json:"end_time"`
+	DurationSeconds  int               `json:"duration_seconds"`
+	DisconnectReason string            `json:"disconnect_reason"`
+	RemoteAddress    string            `json:"remote_address"`
+	RemotePort       int               `json:"remote_port"`
+	SIPCallID        string            `json:"sip_call_id"`
+	Vendor           string            `json:"vendor"`
+	UserAgent        string            `json:"user_agent"`
+	TotalRxPackets   int               `json:"total_rx_packets"`
+	TotalTxPackets   int               `json:"total_tx_packets"`
+	TotalRxBytes     int64             `json:"total_rx_bytes"`
+	TotalTxBytes     int64             `json:"total_tx_bytes"`
+	MediaNode        string            `json:"media_node"`
+	SignalingNode    string            `json:"signaling_node"`
+	Encryption       string            `json:"encryption"`
+	ConversationID   string            `json:"conversation_id"`
+	CallUUID         string            `json:"call_uuid"`
+	ParentID         string            `json:"parent_id"`
+	ResourceURI      string            `json:"resource_uri"`
 }
 
 // ParticipantListResponse represents the response from listing participant history
@@ -219,17 +218,17 @@ type ParticipantListResponse struct {
 
 // RegistrationAlias represents a registration alias history record
 type RegistrationAlias struct {
-	ID             int        `json:"id"`
-	Alias          string     `json:"alias"`
-	RegistrationID string     `json:"registration_id"`
-	Username       string     `json:"username"`
-	Node           string     `json:"node"`
-	Protocol       string     `json:"protocol"`
-	RemoteAddress  string     `json:"remote_address"`
-	IsNatted       bool       `json:"is_natted"`
-	StartTime      *time.Time `json:"start_time"`
-	EndTime        *time.Time `json:"end_time"`
-	ResourceURI    string     `json:"resource_uri"`
+	ID             int                `json:"id"`
+	Alias          string             `json:"alias"`
+	RegistrationID string             `json:"registration_id"`
+	Username       string             `json:"username"`
+	Node           string             `json:"node"`
+	Protocol       string             `json:"protocol"`
+	RemoteAddress  string             `json:"remote_address"`
+	IsNatted       bool               `json:"is_natted"`
+	StartTime      *util.InfinityTime `json:"start_time"`
+	EndTime        *util.InfinityTime `json:"end_time"`
+	ResourceURI    string             `json:"resource_uri"`
 }
 
 // RegistrationAliasListResponse represents the response from listing registration alias history
@@ -246,17 +245,17 @@ type RegistrationAliasListResponse struct {
 
 // WorkerVMStatusEvent represents a worker VM status event history record
 type WorkerVMStatusEvent struct {
-	ID                                int        `json:"id"`
-	EventType                         string     `json:"event_type"`
-	State                             *string    `json:"state"`
-	Context                           *string    `json:"context"`
-	Details                           *string    `json:"details"`
-	TimeChanged                       *time.Time `json:"time_changed"`
-	WorkerVMAddress                   string     `json:"workervm_address"`
-	WorkerVMConfigurationID           *int       `json:"workervm_configuration_id"`
-	WorkerVMConfigurationName         *string    `json:"workervm_configuration_name"`
-	WorkerVMConfigurationLocationName *string    `json:"workervm_configuration_location_name"`
-	ResourceURI                       string     `json:"resource_uri"`
+	ID                                int                `json:"id"`
+	EventType                         string             `json:"event_type"`
+	State                             *string            `json:"state"`
+	Context                           *string            `json:"context"`
+	Details                           *string            `json:"details"`
+	TimeChanged                       *util.InfinityTime `json:"time_changed"`
+	WorkerVMAddress                   string             `json:"workervm_address"`
+	WorkerVMConfigurationID           *int               `json:"workervm_configuration_id"`
+	WorkerVMConfigurationName         *string            `json:"workervm_configuration_name"`
+	WorkerVMConfigurationLocationName *string            `json:"workervm_configuration_location_name"`
+	ResourceURI                       string             `json:"resource_uri"`
 }
 
 // WorkerVMStatusEventListResponse represents the response from listing worker VM status event history

--- a/history/registration_alias_test.go
+++ b/history/registration_alias_test.go
@@ -8,6 +8,7 @@ import (
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
 	"github.com/pexip/go-infinity-sdk/v38/options"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -37,8 +38,8 @@ func TestService_ListRegistrationAliases(t *testing.T) {
 				Protocol:       "SIP",
 				RemoteAddress:  "192.168.1.100",
 				IsNatted:       false,
-				StartTime:      &time.Time{},
-				EndTime:        &time.Time{},
+				StartTime:      &util.InfinityTime{},
+				EndTime:        &util.InfinityTime{},
 				ResourceURI:    "/api/admin/history/v1/registration_alias/1/",
 			},
 		},
@@ -72,8 +73,8 @@ func TestService_GetRegistrationAlias(t *testing.T) {
 		Protocol:       "H323",
 		RemoteAddress:  "10.0.0.50",
 		IsNatted:       true,
-		StartTime:      &time.Time{},
-		EndTime:        &time.Time{},
+		StartTime:      &util.InfinityTime{},
+		EndTime:        &util.InfinityTime{},
 		ResourceURI:    "/api/admin/history/v1/registration_alias/1/",
 	}
 

--- a/history/workervm_status_event_test.go
+++ b/history/workervm_status_event_test.go
@@ -8,6 +8,7 @@ import (
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
 	"github.com/pexip/go-infinity-sdk/v38/options"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -41,7 +42,7 @@ func TestService_ListWorkerVMStatusEvents(t *testing.T) {
 				State:                             &state,
 				Context:                           &contextValue,
 				Details:                           &details,
-				TimeChanged:                       &time.Time{},
+				TimeChanged:                       &util.InfinityTime{},
 				WorkerVMAddress:                   "192.168.1.10",
 				WorkerVMConfigurationID:           &configID,
 				WorkerVMConfigurationName:         &configName,
@@ -83,7 +84,7 @@ func TestService_GetWorkerVMStatusEvent(t *testing.T) {
 		State:                             &state,
 		Context:                           &contextValue,
 		Details:                           &details,
-		TimeChanged:                       &time.Time{},
+		TimeChanged:                       &util.InfinityTime{},
 		WorkerVMAddress:                   "192.168.1.20",
 		WorkerVMConfigurationID:           &configID,
 		WorkerVMConfigurationName:         &configName,

--- a/status/alarm_test.go
+++ b/status/alarm_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
+	util "github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -95,7 +96,7 @@ func TestService_GetAlarm(t *testing.T) {
 		Details:    "CPU usage is above 80%",
 		Instance:   "worker-1",
 		Node:       "worker-1",
-		TimeRaised: &timeRaised,
+		TimeRaised: &util.InfinityTime{Time: timeRaised},
 	}
 
 	client.On("GetJSON", t.Context(), "status/v1/alarm/1/", mock.AnythingOfType("*status.Alarm")).Return(nil).Run(func(args mock.Arguments) {

--- a/status/backplane_test.go
+++ b/status/backplane_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
+	util "github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -55,7 +56,7 @@ func TestService_GetBackplane(t *testing.T) {
 		Conference:           "Test Conference",
 		Type:                 "geo-backplane",
 		Protocol:             "MSSIP",
-		ConnectTime:          &connectTime,
+		ConnectTime:          &util.InfinityTime{Time: connectTime},
 		ServiceTag:           "tag123",
 		SystemLocation:       "main-site",
 		MediaNode:            "node1",

--- a/status/backup_request_test.go
+++ b/status/backup_request_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -21,9 +22,9 @@ func TestService_ListBackupRequests(t *testing.T) {
 			{
 				ID:          1,
 				Status:      "completed",
-				Created:     &created,
-				Started:     &started,
-				Completed:   &completed,
+				Created:     &util.InfinityTime{Time: created},
+				Started:     &util.InfinityTime{Time: started},
+				Completed:   &util.InfinityTime{Time: completed},
 				Size:        1024000000,
 				Description: "Scheduled backup",
 				ResourceURI: "/api/admin/status/v1/backup_request/1/",
@@ -31,8 +32,8 @@ func TestService_ListBackupRequests(t *testing.T) {
 			{
 				ID:          2,
 				Status:      "running",
-				Created:     &created,
-				Started:     &started,
+				Created:     &util.InfinityTime{Time: created},
+				Started:     &util.InfinityTime{Time: started},
 				Size:        0,
 				Description: "Manual backup",
 				ResourceURI: "/api/admin/status/v1/backup_request/2/",
@@ -67,9 +68,9 @@ func TestService_GetBackupRequest(t *testing.T) {
 	expectedRequest := &BackupRequest{
 		ID:          1,
 		Status:      "completed",
-		Created:     &created,
-		Started:     &started,
-		Completed:   &completed,
+		Created:     &util.InfinityTime{Time: created},
+		Started:     &util.InfinityTime{Time: started},
+		Completed:   &util.InfinityTime{Time: completed},
 		Size:        2048000000,
 		Description: "Full system backup",
 		ResourceURI: "/api/admin/status/v1/backup_request/1/",

--- a/status/cloud_node_test.go
+++ b/status/cloud_node_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
+	util "github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -23,8 +24,8 @@ func TestService_ListCloudNodes(t *testing.T) {
 				Status:             "running",
 				InstanceType:       "m5.large",
 				Region:             "us-west-2",
-				LaunchTime:         &launchTime,
-				LastContactTime:    &lastContactTime,
+				LaunchTime:         &util.InfinityTime{Time: launchTime},
+				LastContactTime:    &util.InfinityTime{Time: lastContactTime},
 				CPU:                45.5,
 				Memory:             68.2,
 				ActiveConferences:  3,
@@ -37,8 +38,8 @@ func TestService_ListCloudNodes(t *testing.T) {
 				Status:             "running",
 				InstanceType:       "m5.xlarge",
 				Region:             "us-east-1",
-				LaunchTime:         &launchTime,
-				LastContactTime:    &lastContactTime,
+				LaunchTime:         &util.InfinityTime{Time: launchTime},
+				LastContactTime:    &util.InfinityTime{Time: lastContactTime},
 				CPU:                72.1,
 				Memory:             84.3,
 				ActiveConferences:  5,
@@ -78,8 +79,8 @@ func TestService_GetCloudNode(t *testing.T) {
 		Status:             "running",
 		InstanceType:       "m5.2xlarge",
 		Region:             "eu-west-1",
-		LaunchTime:         &launchTime,
-		LastContactTime:    &lastContactTime,
+		LaunchTime:         &util.InfinityTime{Time: launchTime},
+		LastContactTime:    &util.InfinityTime{Time: lastContactTime},
 		CPU:                85.7,
 		Memory:             76.4,
 		ActiveConferences:  8,

--- a/status/conference_sync_test.go
+++ b/status/conference_sync_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
+	util "github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -20,7 +21,7 @@ func TestService_ListConferenceSyncs(t *testing.T) {
 				ID:           1,
 				Name:         "Primary Sync",
 				Status:       "active",
-				LastSync:     &lastSync,
+				LastSync:     &util.InfinityTime{Time: lastSync},
 				SyncInterval: 300,
 				ErrorMessage: "",
 				ResourceURI:  "/api/admin/status/v1/conference_sync/1/",
@@ -87,7 +88,7 @@ func TestService_GetConferenceSync(t *testing.T) {
 		ID:           1,
 		Name:         "Test Sync",
 		Status:       "syncing",
-		LastSync:     &lastSync,
+		LastSync:     &util.InfinityTime{Time: lastSync},
 		SyncInterval: 600,
 		ErrorMessage: "",
 		ResourceURI:  "/api/admin/status/v1/conference_sync/1/",

--- a/status/exchange_scheduler_test.go
+++ b/status/exchange_scheduler_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -21,8 +22,8 @@ func TestService_ListExchangeSchedulers(t *testing.T) {
 				ID:                1,
 				Name:              "Primary Exchange",
 				Status:            "active",
-				LastSync:          &lastSync,
-				NextSync:          &nextSync,
+				LastSync:          &util.InfinityTime{Time: lastSync},
+				NextSync:          &util.InfinityTime{Time: nextSync},
 				ProcessedMeetings: 45,
 				ErrorCount:        0,
 				ResourceURI:       "/api/admin/status/v1/exchange_scheduler/1/",
@@ -91,8 +92,8 @@ func TestService_GetExchangeScheduler(t *testing.T) {
 		ID:                1,
 		Name:              "Test Exchange",
 		Status:            "syncing",
-		LastSync:          &lastSync,
-		NextSync:          &nextSync,
+		LastSync:          &util.InfinityTime{Time: lastSync},
+		NextSync:          &util.InfinityTime{Time: nextSync},
 		ProcessedMeetings: 12,
 		ErrorCount:        1,
 		ResourceURI:       "/api/admin/status/v1/exchange_scheduler/1/",

--- a/status/management_vm_test.go
+++ b/status/management_vm_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -67,8 +68,8 @@ func TestService_GetManagementVM(t *testing.T) {
 		SyncStatus:           "SYNCED",
 		UpgradeStatus:        "COMPLETE",
 		Version:              "30.1.0",
-		LastAttemptedContact: &lastAttemptedContact,
-		LastUpdated:          &lastUpdated,
+		LastAttemptedContact: &util.InfinityTime{Time: lastAttemptedContact},
+		LastUpdated:          &util.InfinityTime{Time: lastUpdated},
 		ResourceURI:          "/api/admin/status/v1/management_vm/1/",
 	}
 

--- a/status/mjx_endpoint_test.go
+++ b/status/mjx_endpoint_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -21,7 +22,7 @@ func TestService_ListMJXEndpoints(t *testing.T) {
 				Name:              "mjx-endpoint-1",
 				Status:            "connected",
 				EndpointType:      "teams",
-				LastContact:       &lastContact,
+				LastContact:       &util.InfinityTime{Time: lastContact},
 				Version:           "1.5.0",
 				ActiveConnections: 3,
 				ResourceURI:       "/api/admin/status/v1/mjx_endpoint/1/",
@@ -31,7 +32,7 @@ func TestService_ListMJXEndpoints(t *testing.T) {
 				Name:              "mjx-endpoint-2",
 				Status:            "disconnected",
 				EndpointType:      "google",
-				LastContact:       &lastContact,
+				LastContact:       &util.InfinityTime{Time: lastContact},
 				Version:           "1.4.2",
 				ActiveConnections: 0,
 				ResourceURI:       "/api/admin/status/v1/mjx_endpoint/2/",
@@ -69,7 +70,7 @@ func TestService_GetMJXEndpoint(t *testing.T) {
 		Name:              "mjx-primary-endpoint",
 		Status:            "connected",
 		EndpointType:      "teams",
-		LastContact:       &lastContact,
+		LastContact:       &util.InfinityTime{Time: lastContact},
 		Version:           "1.6.0",
 		ActiveConnections: 8,
 		ResourceURI:       "/api/admin/status/v1/mjx_endpoint/1/",

--- a/status/mjx_meeting_test.go
+++ b/status/mjx_meeting_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -21,8 +22,8 @@ func TestService_ListMJXMeetings(t *testing.T) {
 				ID:               "meeting-123",
 				Subject:          "Weekly Team Meeting",
 				Organizer:        "john.doe@company.com",
-				StartTime:        &startTime,
-				EndTime:          &endTime,
+				StartTime:        &util.InfinityTime{Time: startTime},
+				EndTime:          &util.InfinityTime{Time: endTime},
 				Status:           "active",
 				ParticipantCount: 8,
 				ConferenceAlias:  "team-weekly",
@@ -65,8 +66,8 @@ func TestService_ListMJXMeetings_WithOptions(t *testing.T) {
 				ID:               "meeting-options-test",
 				Subject:          "Test Meeting With Options",
 				Organizer:        "test@company.com",
-				StartTime:        &startTime,
-				EndTime:          &endTime,
+				StartTime:        &util.InfinityTime{Time: startTime},
+				EndTime:          &util.InfinityTime{Time: endTime},
 				Status:           "active",
 				ParticipantCount: 5,
 				ConferenceAlias:  "test-options",
@@ -98,8 +99,8 @@ func TestService_GetMJXMeeting(t *testing.T) {
 		ID:               "meeting-456",
 		Subject:          "Board Meeting",
 		Organizer:        "ceo@company.com",
-		StartTime:        &startTime,
-		EndTime:          &endTime,
+		StartTime:        &util.InfinityTime{Time: startTime},
+		EndTime:          &util.InfinityTime{Time: endTime},
 		Status:           "completed",
 		ParticipantCount: 12,
 		ConferenceAlias:  "board-meeting",

--- a/status/models.go
+++ b/status/models.go
@@ -1,7 +1,7 @@
 package status
 
 import (
-	"time"
+	util "github.com/pexip/go-infinity-sdk/v38/util"
 )
 
 // Meta represents the pagination metadata for list responses
@@ -15,135 +15,135 @@ type Meta struct {
 
 // SystemStatus represents the overall system status
 type SystemStatus struct {
-	Status      string    `json:"status"`
-	Version     string    `json:"version"`
-	Uptime      int       `json:"uptime"`
-	Timestamp   time.Time `json:"timestamp"`
-	HostName    string    `json:"hostname"`
-	TotalMemory int64     `json:"total_memory"`
-	UsedMemory  int64     `json:"used_memory"`
-	CPULoad     float64   `json:"cpu_load"`
+	Status      string            `json:"status"`
+	Version     string            `json:"version"`
+	Uptime      int               `json:"uptime"`
+	Timestamp   util.InfinityTime `json:"timestamp"`
+	HostName    string            `json:"hostname"`
+	TotalMemory int64             `json:"total_memory"`
+	UsedMemory  int64             `json:"used_memory"`
+	CPULoad     float64           `json:"cpu_load"`
 }
 
 // ConferenceStatus represents a conference status
 type ConferenceStatus struct {
-	ID                   string     `json:"id"`
-	Name                 string     `json:"name"`
-	ServiceType          string     `json:"service_type"`
-	IsStarted            bool       `json:"is_started"`
-	IsLocked             bool       `json:"is_locked"`
-	GuestsMuted          bool       `json:"guests_muted"`
-	DirectMediaAvailable bool       `json:"direct_media_available"`
-	StartTime            *time.Time `json:"start_time,omitempty"`
-	Tag                  string     `json:"tag"`
-	ResourceURI          string     `json:"resource_uri"`
+	ID                   string             `json:"id"`
+	Name                 string             `json:"name"`
+	ServiceType          string             `json:"service_type"`
+	IsStarted            bool               `json:"is_started"`
+	IsLocked             bool               `json:"is_locked"`
+	GuestsMuted          bool               `json:"guests_muted"`
+	DirectMediaAvailable bool               `json:"direct_media_available"`
+	StartTime            *util.InfinityTime `json:"start_time,omitempty"`
+	Tag                  string             `json:"tag"`
+	ResourceURI          string             `json:"resource_uri"`
 }
 
 // Participant represents a participant status
 type Participant struct {
-	ID               string    `json:"id"`
-	UUID             string    `json:"uuid"`
-	DisplayName      string    `json:"display_name"`
-	ConferenceID     int       `json:"conference_id"`
-	ConferenceName   string    `json:"conference_name"`
-	ServiceType      string    `json:"service_type"`
-	Role             string    `json:"role"`
-	ConnectTime      time.Time `json:"connect_time"`
-	IsOnHold         bool      `json:"is_on_hold"`
-	IsMuted          bool      `json:"is_muted"`
-	IsGuest          bool      `json:"is_guest"`
-	IsWaiting        bool      `json:"is_waiting"`
-	HasMedia         bool      `json:"has_media"`
-	IsPresenting     bool      `json:"is_presenting"`
-	Bandwidth        int       `json:"bandwidth"`
-	CallDirection    string    `json:"call_direction"`
-	CallUUID         string    `json:"call_uuid"`
-	DestinationAlias string    `json:"destination_alias"`
-	SourceAlias      string    `json:"source_alias"`
-	RemoteAddress    string    `json:"remote_address"`
-	RemotePort       int       `json:"remote_port"`
-	Protocol         string    `json:"protocol"`
-	VendorID         string    `json:"vendor_id"`
-	ParentID         string    `json:"parent_id"`
-	SystemLocation   string    `json:"system_location"`
-	NodeID           string    `json:"node_id"`
-	ResourceURI      string    `json:"resource_uri"`
+	ID               string            `json:"id"`
+	UUID             string            `json:"uuid"`
+	DisplayName      string            `json:"display_name"`
+	ConferenceID     int               `json:"conference_id"`
+	ConferenceName   string            `json:"conference_name"`
+	ServiceType      string            `json:"service_type"`
+	Role             string            `json:"role"`
+	ConnectTime      util.InfinityTime `json:"connect_time"`
+	IsOnHold         bool              `json:"is_on_hold"`
+	IsMuted          bool              `json:"is_muted"`
+	IsGuest          bool              `json:"is_guest"`
+	IsWaiting        bool              `json:"is_waiting"`
+	HasMedia         bool              `json:"has_media"`
+	IsPresenting     bool              `json:"is_presenting"`
+	Bandwidth        int               `json:"bandwidth"`
+	CallDirection    string            `json:"call_direction"`
+	CallUUID         string            `json:"call_uuid"`
+	DestinationAlias string            `json:"destination_alias"`
+	SourceAlias      string            `json:"source_alias"`
+	RemoteAddress    string            `json:"remote_address"`
+	RemotePort       int               `json:"remote_port"`
+	Protocol         string            `json:"protocol"`
+	VendorID         string            `json:"vendor_id"`
+	ParentID         string            `json:"parent_id"`
+	SystemLocation   string            `json:"system_location"`
+	NodeID           string            `json:"node_id"`
+	ResourceURI      string            `json:"resource_uri"`
 }
 
 // WorkerVM represents a worker node status
 type WorkerVM struct {
-	ID                    int        `json:"id"`
-	ConfigurationID       int        `json:"configuration_id"`
-	Name                  string     `json:"name"`
-	NodeType              string     `json:"node_type"`
-	SystemLocation        string     `json:"system_location"`
-	SyncStatus            string     `json:"sync_status"`
-	UpgradeStatus         string     `json:"upgrade_status"`
-	Version               string     `json:"version"`
-	BootTime              *time.Time `json:"boot_time,omitempty"`
-	LastAttemptedContact  *time.Time `json:"last_attempted_contact,omitempty"`
-	LastUpdated           *time.Time `json:"last_updated,omitempty"`
-	MaintenanceMode       bool       `json:"maintenance_mode"`
-	MaintenanceModeReason string     `json:"maintenance_mode_reason"`
-	CPUCapabilities       string     `json:"cpu_capabilities"`
-	CPUCount              int        `json:"cpu_count"`
-	CPUModel              string     `json:"cpu_model"`
-	TotalRAM              int        `json:"total_ram"`
-	Hypervisor            string     `json:"hypervisor"`
-	DeployStatus          string     `json:"deploy_status"`
-	MaxAudioCalls         int        `json:"max_audio_calls"`
-	MaxSDCalls            int        `json:"max_sd_calls"`
-	MaxHDCalls            int        `json:"max_hd_calls"`
-	MaxFullHDCalls        int        `json:"max_full_hd_calls"`
-	MaxDirectParticipants int        `json:"max_direct_participants"`
-	MaxMediaTokens        int        `json:"max_media_tokens"`
-	MediaTokensUsed       int        `json:"media_tokens_used"`
-	MediaLoad             int        `json:"media_load"`
-	SignalingCount        int        `json:"signaling_count"`
-	ResourceURI           string     `json:"resource_uri"`
+	ID                    int                `json:"id"`
+	ConfigurationID       int                `json:"configuration_id"`
+	Name                  string             `json:"name"`
+	NodeType              string             `json:"node_type"`
+	SystemLocation        string             `json:"system_location"`
+	SyncStatus            string             `json:"sync_status"`
+	UpgradeStatus         string             `json:"upgrade_status"`
+	Version               string             `json:"version"`
+	BootTime              *util.InfinityTime `json:"boot_time,omitempty"`
+	LastAttemptedContact  *util.InfinityTime `json:"last_attempted_contact,omitempty"`
+	LastUpdated           *util.InfinityTime `json:"last_updated,omitempty"`
+	MaintenanceMode       bool               `json:"maintenance_mode"`
+	MaintenanceModeReason string             `json:"maintenance_mode_reason"`
+	CPUCapabilities       string             `json:"cpu_capabilities"`
+	CPUCount              int                `json:"cpu_count"`
+	CPUModel              string             `json:"cpu_model"`
+	TotalRAM              int                `json:"total_ram"`
+	Hypervisor            string             `json:"hypervisor"`
+	DeployStatus          string             `json:"deploy_status"`
+	MaxAudioCalls         int                `json:"max_audio_calls"`
+	MaxSDCalls            int                `json:"max_sd_calls"`
+	MaxHDCalls            int                `json:"max_hd_calls"`
+	MaxFullHDCalls        int                `json:"max_full_hd_calls"`
+	MaxDirectParticipants int                `json:"max_direct_participants"`
+	MaxMediaTokens        int                `json:"max_media_tokens"`
+	MediaTokensUsed       int                `json:"media_tokens_used"`
+	MediaLoad             int                `json:"media_load"`
+	SignalingCount        int                `json:"signaling_count"`
+	ResourceURI           string             `json:"resource_uri"`
 }
 
 // Alarm represents a system alarm
 type Alarm struct {
-	ID           int        `json:"id"`
-	Identifier   int        `json:"identifier"`
-	Level        string     `json:"level"`
-	Name         string     `json:"name"`
-	Details      string     `json:"details"`
-	Instance     string     `json:"instance"`
-	Node         string     `json:"node"`
-	Acknowledged bool       `json:"acknowledged"`
-	TimeRaised   *time.Time `json:"time_raised,omitempty"`
-	ResourceURI  string     `json:"resource_uri"`
+	ID           int                `json:"id"`
+	Identifier   int                `json:"identifier"`
+	Level        string             `json:"level"`
+	Name         string             `json:"name"`
+	Details      string             `json:"details"`
+	Instance     string             `json:"instance"`
+	Node         string             `json:"node"`
+	Acknowledged bool               `json:"acknowledged"`
+	TimeRaised   *util.InfinityTime `json:"time_raised,omitempty"`
+	ResourceURI  string             `json:"resource_uri"`
 }
 
 // Backplane represents a backplane connection status
 type Backplane struct {
-	ID                   string     `json:"id"`
-	Conference           string     `json:"conference"`
-	Type                 string     `json:"type"`
-	Protocol             string     `json:"protocol"`
-	ConnectTime          *time.Time `json:"connect_time,omitempty"`
-	ServiceTag           string     `json:"service_tag"`
-	SystemLocation       string     `json:"system_location"`
-	MediaNode            string     `json:"media_node"`
-	ProxyNode            string     `json:"proxy_node"`
-	RemoteConferenceName string     `json:"remote_conference_name"`
-	RemoteMediaNode      string     `json:"remote_media_node"`
-	RemoteNodeName       string     `json:"remote_node_name"`
-	ResourceURI          string     `json:"resource_uri"`
+	ID                   string             `json:"id"`
+	Conference           string             `json:"conference"`
+	Type                 string             `json:"type"`
+	Protocol             string             `json:"protocol"`
+	ConnectTime          *util.InfinityTime `json:"connect_time,omitempty"`
+	ServiceTag           string             `json:"service_tag"`
+	SystemLocation       string             `json:"system_location"`
+	MediaNode            string             `json:"media_node"`
+	ProxyNode            string             `json:"proxy_node"`
+	RemoteConferenceName string             `json:"remote_conference_name"`
+	RemoteMediaNode      string             `json:"remote_media_node"`
+	RemoteNodeName       string             `json:"remote_node_name"`
+	ResourceURI          string             `json:"resource_uri"`
 }
 
 // BackupRequest represents a backup request status
 type BackupRequest struct {
-	ID          int        `json:"id"`
-	Status      string     `json:"status"`
-	Created     *time.Time `json:"created,omitempty"`
-	Started     *time.Time `json:"started,omitempty"`
-	Completed   *time.Time `json:"completed,omitempty"`
-	Size        int64      `json:"size"`
-	Description string     `json:"description"`
-	ResourceURI string     `json:"resource_uri"`
+	ID          int                `json:"id"`
+	Status      string             `json:"status"`
+	Created     *util.InfinityTime `json:"created,omitempty"`
+	Started     *util.InfinityTime `json:"started,omitempty"`
+	Completed   *util.InfinityTime `json:"completed,omitempty"`
+	Size        int64              `json:"size"`
+	Description string             `json:"description"`
+	ResourceURI string             `json:"resource_uri"`
 }
 
 // CloudMonitoredLocation represents a cloud monitored location status
@@ -159,18 +159,18 @@ type CloudMonitoredLocation struct {
 
 // CloudNode represents a cloud node status
 type CloudNode struct {
-	ID                 string     `json:"id"`
-	Name               string     `json:"name"`
-	Status             string     `json:"status"`
-	InstanceType       string     `json:"instance_type"`
-	Region             string     `json:"region"`
-	LaunchTime         *time.Time `json:"launch_time,omitempty"`
-	LastContactTime    *time.Time `json:"last_contact_time,omitempty"`
-	CPU                float64    `json:"cpu"`
-	Memory             float64    `json:"memory"`
-	ActiveConferences  int        `json:"active_conferences"`
-	ActiveParticipants int        `json:"active_participants"`
-	ResourceURI        string     `json:"resource_uri"`
+	ID                 string             `json:"id"`
+	Name               string             `json:"name"`
+	Status             string             `json:"status"`
+	InstanceType       string             `json:"instance_type"`
+	Region             string             `json:"region"`
+	LaunchTime         *util.InfinityTime `json:"launch_time,omitempty"`
+	LastContactTime    *util.InfinityTime `json:"last_contact_time,omitempty"`
+	CPU                float64            `json:"cpu"`
+	Memory             float64            `json:"memory"`
+	ActiveConferences  int                `json:"active_conferences"`
+	ActiveParticipants int                `json:"active_participants"`
+	ResourceURI        string             `json:"resource_uri"`
 }
 
 // CloudOverflowLocation represents a cloud overflow location status
@@ -195,25 +195,25 @@ type ConferenceShard struct {
 
 // ConferenceSync represents a conference sync status
 type ConferenceSync struct {
-	ID           int        `json:"id"`
-	Name         string     `json:"name"`
-	Status       string     `json:"status"`
-	LastSync     *time.Time `json:"last_sync,omitempty"`
-	SyncInterval int        `json:"sync_interval"`
-	ErrorMessage string     `json:"error_message"`
-	ResourceURI  string     `json:"resource_uri"`
+	ID           int                `json:"id"`
+	Name         string             `json:"name"`
+	Status       string             `json:"status"`
+	LastSync     *util.InfinityTime `json:"last_sync,omitempty"`
+	SyncInterval int                `json:"sync_interval"`
+	ErrorMessage string             `json:"error_message"`
+	ResourceURI  string             `json:"resource_uri"`
 }
 
 // ExchangeScheduler represents an Exchange scheduler status
 type ExchangeScheduler struct {
-	ID                int        `json:"id"`
-	Name              string     `json:"name"`
-	Status            string     `json:"status"`
-	LastSync          *time.Time `json:"last_sync,omitempty"`
-	NextSync          *time.Time `json:"next_sync,omitempty"`
-	ProcessedMeetings int        `json:"processed_meetings"`
-	ErrorCount        int        `json:"error_count"`
-	ResourceURI       string     `json:"resource_uri"`
+	ID                int                `json:"id"`
+	Name              string             `json:"name"`
+	Status            string             `json:"status"`
+	LastSync          *util.InfinityTime `json:"last_sync,omitempty"`
+	NextSync          *util.InfinityTime `json:"next_sync,omitempty"`
+	ProcessedMeetings int                `json:"processed_meetings"`
+	ErrorCount        int                `json:"error_count"`
+	ResourceURI       string             `json:"resource_uri"`
 }
 
 // Licensing represents licensing status
@@ -241,41 +241,41 @@ type Licensing struct {
 
 // ManagementVM represents a management VM status
 type ManagementVM struct {
-	ID                   int        `json:"id"`
-	ConfigurationID      int        `json:"configuration_id"`
-	Name                 string     `json:"name"`
-	Primary              bool       `json:"primary"`
-	SyncStatus           string     `json:"sync_status"`
-	UpgradeStatus        string     `json:"upgrade_status"`
-	Version              string     `json:"version"`
-	LastAttemptedContact *time.Time `json:"last_attempted_contact,omitempty"`
-	LastUpdated          *time.Time `json:"last_updated,omitempty"`
-	ResourceURI          string     `json:"resource_uri"`
+	ID                   int                `json:"id"`
+	ConfigurationID      int                `json:"configuration_id"`
+	Name                 string             `json:"name"`
+	Primary              bool               `json:"primary"`
+	SyncStatus           string             `json:"sync_status"`
+	UpgradeStatus        string             `json:"upgrade_status"`
+	Version              string             `json:"version"`
+	LastAttemptedContact *util.InfinityTime `json:"last_attempted_contact,omitempty"`
+	LastUpdated          *util.InfinityTime `json:"last_updated,omitempty"`
+	ResourceURI          string             `json:"resource_uri"`
 }
 
 // MJXEndpoint represents an MJX endpoint status
 type MJXEndpoint struct {
-	ID                int        `json:"id"`
-	Name              string     `json:"name"`
-	Status            string     `json:"status"`
-	EndpointType      string     `json:"endpoint_type"`
-	LastContact       *time.Time `json:"last_contact,omitempty"`
-	Version           string     `json:"version"`
-	ActiveConnections int        `json:"active_connections"`
-	ResourceURI       string     `json:"resource_uri"`
+	ID                int                `json:"id"`
+	Name              string             `json:"name"`
+	Status            string             `json:"status"`
+	EndpointType      string             `json:"endpoint_type"`
+	LastContact       *util.InfinityTime `json:"last_contact,omitempty"`
+	Version           string             `json:"version"`
+	ActiveConnections int                `json:"active_connections"`
+	ResourceURI       string             `json:"resource_uri"`
 }
 
 // MJXMeeting represents an MJX meeting status
 type MJXMeeting struct {
-	ID               string     `json:"id"`
-	Subject          string     `json:"subject"`
-	Organizer        string     `json:"organizer"`
-	StartTime        *time.Time `json:"start_time,omitempty"`
-	EndTime          *time.Time `json:"end_time,omitempty"`
-	Status           string     `json:"status"`
-	ParticipantCount int        `json:"participant_count"`
-	ConferenceAlias  string     `json:"conference_alias"`
-	ResourceURI      string     `json:"resource_uri"`
+	ID               string             `json:"id"`
+	Subject          string             `json:"subject"`
+	Organizer        string             `json:"organizer"`
+	StartTime        *util.InfinityTime `json:"start_time,omitempty"`
+	EndTime          *util.InfinityTime `json:"end_time,omitempty"`
+	Status           string             `json:"status"`
+	ParticipantCount int                `json:"participant_count"`
+	ConferenceAlias  string             `json:"conference_alias"`
+	ResourceURI      string             `json:"resource_uri"`
 }
 
 // RegistrationAlias represents a registration alias status
@@ -290,26 +290,26 @@ type RegistrationAlias struct {
 
 // SchedulingOperation represents a scheduling operation status
 type SchedulingOperation struct {
-	ID             int        `json:"id"`
-	OperationType  string     `json:"operation_type"`
-	Status         string     `json:"status"`
-	CreatedTime    *time.Time `json:"created_time,omitempty"`
-	CompletedTime  *time.Time `json:"completed_time,omitempty"`
-	ErrorMessage   string     `json:"error_message"`
-	ConferenceName string     `json:"conference_name"`
-	ResourceURI    string     `json:"resource_uri"`
+	ID             int                `json:"id"`
+	OperationType  string             `json:"operation_type"`
+	Status         string             `json:"status"`
+	CreatedTime    *util.InfinityTime `json:"created_time,omitempty"`
+	CompletedTime  *util.InfinityTime `json:"completed_time,omitempty"`
+	ErrorMessage   string             `json:"error_message"`
+	ConferenceName string             `json:"conference_name"`
+	ResourceURI    string             `json:"resource_uri"`
 }
 
 // SnapshotRequest represents a snapshot request status
 type SnapshotRequest struct {
-	ID          int        `json:"id"`
-	Status      string     `json:"status"`
-	Created     *time.Time `json:"created,omitempty"`
-	Started     *time.Time `json:"started,omitempty"`
-	Completed   *time.Time `json:"completed,omitempty"`
-	Size        int64      `json:"size"`
-	Description string     `json:"description"`
-	ResourceURI string     `json:"resource_uri"`
+	ID          int                `json:"id"`
+	Status      string             `json:"status"`
+	Created     *util.InfinityTime `json:"created,omitempty"`
+	Started     *util.InfinityTime `json:"started,omitempty"`
+	Completed   *util.InfinityTime `json:"completed,omitempty"`
+	Size        int64              `json:"size"`
+	Description string             `json:"description"`
+	ResourceURI string             `json:"resource_uri"`
 }
 
 // SystemLocation represents a system location status
@@ -325,26 +325,26 @@ type SystemLocation struct {
 
 // TeamsNode represents a Teams node status
 type TeamsNode struct {
-	ID          int        `json:"id"`
-	Name        string     `json:"name"`
-	Status      string     `json:"status"`
-	Version     string     `json:"version"`
-	LastContact *time.Time `json:"last_contact,omitempty"`
-	ActiveCalls int        `json:"active_calls"`
-	ResourceURI string     `json:"resource_uri"`
+	ID          int                `json:"id"`
+	Name        string             `json:"name"`
+	Status      string             `json:"status"`
+	Version     string             `json:"version"`
+	LastContact *util.InfinityTime `json:"last_contact,omitempty"`
+	ActiveCalls int                `json:"active_calls"`
+	ResourceURI string             `json:"resource_uri"`
 }
 
 // TeamsNodeCall represents a Teams node call status
 type TeamsNodeCall struct {
-	ID              string     `json:"id"`
-	TeamsNodeID     int        `json:"teams_node_id"`
-	ConferenceName  string     `json:"conference_name"`
-	ParticipantName string     `json:"participant_name"`
-	CallDirection   string     `json:"call_direction"`
-	StartTime       *time.Time `json:"start_time,omitempty"`
-	Duration        int        `json:"duration"`
-	Status          string     `json:"status"`
-	ResourceURI     string     `json:"resource_uri"`
+	ID              string             `json:"id"`
+	TeamsNodeID     int                `json:"teams_node_id"`
+	ConferenceName  string             `json:"conference_name"`
+	ParticipantName string             `json:"participant_name"`
+	CallDirection   string             `json:"call_direction"`
+	StartTime       *util.InfinityTime `json:"start_time,omitempty"`
+	Duration        int                `json:"duration"`
+	Status          string             `json:"status"`
+	ResourceURI     string             `json:"resource_uri"`
 }
 
 type ConferenceListResponse struct {

--- a/status/scheduling_operation_test.go
+++ b/status/scheduling_operation_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -21,8 +22,8 @@ func TestService_ListSchedulingOperations(t *testing.T) {
 				ID:             1,
 				OperationType:  "create",
 				Status:         "completed",
-				CreatedTime:    &createdTime,
-				CompletedTime:  &completedTime,
+				CreatedTime:    &util.InfinityTime{Time: createdTime},
+				CompletedTime:  &util.InfinityTime{Time: completedTime},
 				ErrorMessage:   "",
 				ConferenceName: "Test Meeting",
 				ResourceURI:    "/api/admin/status/v1/scheduling_operation/1/",
@@ -61,7 +62,7 @@ func TestService_ListSchedulingOperations_WithOptions(t *testing.T) {
 				ID:             2,
 				OperationType:  "delete",
 				Status:         "completed",
-				CreatedTime:    &createdTime,
+				CreatedTime:    &util.InfinityTime{Time: createdTime},
 				ErrorMessage:   "",
 				ConferenceName: "Test Meeting With Options",
 			},
@@ -91,7 +92,7 @@ func TestService_GetSchedulingOperation(t *testing.T) {
 		ID:             1,
 		OperationType:  "update",
 		Status:         "running",
-		CreatedTime:    &createdTime,
+		CreatedTime:    &util.InfinityTime{Time: createdTime},
 		ErrorMessage:   "",
 		ConferenceName: "Updated Meeting",
 		ResourceURI:    "/api/admin/status/v1/scheduling_operation/1/",

--- a/status/snapshot_request_test.go
+++ b/status/snapshot_request_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -21,9 +22,9 @@ func TestService_ListSnapshotRequests(t *testing.T) {
 			{
 				ID:          1,
 				Status:      "completed",
-				Created:     &created,
-				Started:     &started,
-				Completed:   &completed,
+				Created:     &util.InfinityTime{Time: created},
+				Started:     &util.InfinityTime{Time: started},
+				Completed:   &util.InfinityTime{Time: completed},
 				Size:        512000000,
 				Description: "Daily snapshot",
 				ResourceURI: "/api/admin/status/v1/snapshot_request/1/",
@@ -63,8 +64,8 @@ func TestService_ListSnapshotRequests_WithOptions(t *testing.T) {
 			{
 				ID:          2,
 				Status:      "completed",
-				Created:     &created,
-				Completed:   &completed,
+				Created:     &util.InfinityTime{Time: created},
+				Completed:   &util.InfinityTime{Time: completed},
 				Size:        1024000000,
 				Description: "Options Test Snapshot",
 			},
@@ -94,8 +95,8 @@ func TestService_GetSnapshotRequest(t *testing.T) {
 	expectedRequest := &SnapshotRequest{
 		ID:          1,
 		Status:      "running",
-		Created:     &created,
-		Started:     &started,
+		Created:     &util.InfinityTime{Time: created},
+		Started:     &util.InfinityTime{Time: started},
 		Size:        0,
 		Description: "Manual snapshot",
 		ResourceURI: "/api/admin/status/v1/snapshot_request/1/",

--- a/status/system_status_test.go
+++ b/status/system_status_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -16,7 +17,7 @@ func TestService_GetSystemStatus(t *testing.T) {
 		Status:      "healthy",
 		Version:     "29.0.0",
 		Uptime:      3600,
-		Timestamp:   time.Now(),
+		Timestamp:   util.InfinityTime{Time: time.Now()},
 		HostName:    "pexip-mgmt",
 		TotalMemory: 8589934592,
 		UsedMemory:  4294967296,

--- a/status/teamsnode_call_test.go
+++ b/status/teamsnode_call_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -22,7 +23,7 @@ func TestService_ListTeamsNodeCalls(t *testing.T) {
 				ConferenceName:  "Team Meeting",
 				ParticipantName: "John Doe",
 				CallDirection:   "inbound",
-				StartTime:       &startTime,
+				StartTime:       &util.InfinityTime{Time: startTime},
 				Duration:        1800,
 				Status:          "active",
 				ResourceURI:     "/api/admin/status/v1/teamsnode_call/call-123/",
@@ -66,7 +67,7 @@ func TestService_ListTeamsNodeCalls_WithOptions(t *testing.T) {
 				ConferenceName:  "Options Test Meeting",
 				ParticipantName: "Test User",
 				CallDirection:   "inbound",
-				StartTime:       &startTime,
+				StartTime:       &util.InfinityTime{Time: startTime},
 				Duration:        900,
 				Status:          "active",
 			},
@@ -98,7 +99,7 @@ func TestService_GetTeamsNodeCall(t *testing.T) {
 		ConferenceName:  "Executive Meeting",
 		ParticipantName: "Jane Smith",
 		CallDirection:   "outbound",
-		StartTime:       &startTime,
+		StartTime:       &util.InfinityTime{Time: startTime},
 		Duration:        3600,
 		Status:          "completed",
 		ResourceURI:     "/api/admin/status/v1/teamsnode_call/call-456/",

--- a/status/teamsnode_test.go
+++ b/status/teamsnode_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	mockClient "github.com/pexip/go-infinity-sdk/v38/internal/mock"
+	"github.com/pexip/go-infinity-sdk/v38/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -21,7 +22,7 @@ func TestService_ListTeamsNodes(t *testing.T) {
 				Name:        "teams-node-1",
 				Status:      "active",
 				Version:     "2.0.1",
-				LastContact: &lastContact,
+				LastContact: &util.InfinityTime{Time: lastContact},
 				ActiveCalls: 5,
 				ResourceURI: "/api/admin/status/v1/teamsnode/1/",
 			},
@@ -30,7 +31,7 @@ func TestService_ListTeamsNodes(t *testing.T) {
 				Name:        "teams-node-2",
 				Status:      "inactive",
 				Version:     "2.0.0",
-				LastContact: &lastContact,
+				LastContact: &util.InfinityTime{Time: lastContact},
 				ActiveCalls: 0,
 				ResourceURI: "/api/admin/status/v1/teamsnode/2/",
 			},
@@ -66,7 +67,7 @@ func TestService_GetTeamsNode(t *testing.T) {
 		Name:        "teams-node-primary",
 		Status:      "active",
 		Version:     "2.1.0",
-		LastContact: &lastContact,
+		LastContact: &util.InfinityTime{Time: lastContact},
 		ActiveCalls: 12,
 		ResourceURI: "/api/admin/status/v1/teamsnode/1/",
 	}

--- a/util/infinity_time.go
+++ b/util/infinity_time.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"strings"
+	"time"
+)
+
+// InfinityTime is a custom time type that can handle both UTC and local time formats
+type InfinityTime struct {
+	time.Time
+}
+
+func (ft *InfinityTime) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), "\"")
+	var err error
+	// Try with timezone
+	ft.Time, err = time.Parse("2006-01-02T15:04:05.000000Z07:00", s)
+	if err == nil {
+		return nil
+	}
+	// Try without timezone
+	ft.Time, err = time.Parse("2006-01-02T15:04:05.000000", s)
+	return err
+}


### PR DESCRIPTION
# Description

This PR replaces direct use of time.Time in status, history, and config models with util.InfinityTime to support unmarshalling of timestamps with or without fractional parts. Corresponding tests are updated to wrap their time variables in InfinityTime.

- Use util.InfinityTime instead of time.Time in all affected model structs
- Adjust all imports and remove unused "time" where it’s no longer needed
- Update test fixtures to construct InfinityTime instances around existing time.Time values

Fixes # (issue)

## Change management

See project labels for change classification and risk.

Change reason?

Please describe the reason for the change here.

Change rollback plan?

If nothing else is specified, the change will be rolled back by reverting the commit.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration