### PR TITLE
feat: update GetJSON method to accept query parameters

### DIFF
--- a/client_mock.go
+++ b/client_mock.go
@@ -8,6 +8,8 @@ package infinity
 
 import (
 	"context"
+	"net/url"
+
 	"github.com/pexip/go-infinity-sdk/v38/command"
 	"github.com/pexip/go-infinity-sdk/v38/config"
 	"github.com/pexip/go-infinity-sdk/v38/history"
@@ -57,8 +59,8 @@ func (client *ClientMock) Command() *command.Service {
 }
 
 // GetJSON mocks the GetJSON method
-func (m *ClientMock) GetJSON(ctx context.Context, endpoint string, result interface{}) error {
-	args := m.Called(ctx, endpoint, result)
+func (m *ClientMock) GetJSON(ctx context.Context, endpoint string, queryParams *url.Values, result interface{}) error {
+	args := m.Called(ctx, endpoint, queryParams, result)
 	return args.Error(0)
 }
 

--- a/client_retry_benchmark_test.go
+++ b/client_retry_benchmark_test.go
@@ -38,7 +38,7 @@ func BenchmarkClient_SuccessfulRequestNoRetry(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		var result map[string]interface{}
-		err := client.GetJSON(context.Background(), "test", &result)
+		err := client.GetJSON(context.Background(), "test", nil, &result)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -75,7 +75,7 @@ func BenchmarkClient_SuccessfulRequestAfterRetries(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		var result map[string]interface{}
-		err := client.GetJSON(context.Background(), "test", &result)
+		err := client.GetJSON(context.Background(), "test", nil, &result)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/client_retry_integration_test.go
+++ b/client_retry_integration_test.go
@@ -61,7 +61,7 @@ func TestRetryIntegration(t *testing.T) {
 		atomic.StoreInt64(&callCount, 0) // Reset counter
 
 		var result map[string]interface{}
-		err := client.GetJSON(context.Background(), "test", &result)
+		err := client.GetJSON(context.Background(), "test", nil, &result)
 
 		assert.NoError(t, err)
 		assert.Equal(t, "success", result["status"])
@@ -94,7 +94,7 @@ func TestRetryIntegration(t *testing.T) {
 		require.NoError(t, err)
 
 		var result map[string]interface{}
-		err = badClient.GetJSON(context.Background(), "test", &result)
+		err = badClient.GetJSON(context.Background(), "test", nil, &result)
 
 		assert.Error(t, err)
 		assert.Equal(t, int64(1), atomic.LoadInt64(&callCount)) // Should only try once
@@ -126,7 +126,7 @@ func TestRetryBackoffTiming(t *testing.T) {
 
 	start := time.Now()
 	var result map[string]interface{}
-	err = client.GetJSON(context.Background(), "test", &result)
+	err = client.GetJSON(context.Background(), "test", nil, &result)
 
 	assert.Error(t, err)
 	assert.Len(t, callTimes, 4) // 1 initial + 3 retries

--- a/client_retry_test.go
+++ b/client_retry_test.go
@@ -203,7 +203,7 @@ func TestClient_RetryOnServerError(t *testing.T) {
 	require.NoError(t, err)
 
 	var result map[string]interface{}
-	err = client.GetJSON(context.Background(), "test", &result)
+	err = client.GetJSON(context.Background(), "test", nil, &result)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "success", result["status"])
@@ -232,7 +232,7 @@ func TestClient_RetryOnNetworkError(t *testing.T) {
 	require.NoError(t, err)
 
 	var result map[string]interface{}
-	err = client.GetJSON(context.Background(), "test", &result)
+	err = client.GetJSON(context.Background(), "test", nil, &result)
 
 	// Should fail after exhausting retries
 	assert.Error(t, err)
@@ -261,7 +261,7 @@ func TestClient_NoRetryOnClientError(t *testing.T) {
 	require.NoError(t, err)
 
 	var result map[string]interface{}
-	err = client.GetJSON(context.Background(), "test", &result)
+	err = client.GetJSON(context.Background(), "test", nil, &result)
 
 	assert.Error(t, err)
 	assert.Equal(t, 1, attemptCount) // Should only try once
@@ -288,7 +288,7 @@ func TestClient_RetryExhaustion(t *testing.T) {
 	require.NoError(t, err)
 
 	var result map[string]interface{}
-	err = client.GetJSON(context.Background(), "test", &result)
+	err = client.GetJSON(context.Background(), "test", nil, &result)
 
 	assert.Error(t, err)
 	assert.Equal(t, 3, attemptCount) // Should try 3 times total (1 initial + 2 retries)
@@ -318,7 +318,7 @@ func TestClient_ContextCancellation(t *testing.T) {
 	defer cancel()
 
 	var result map[string]interface{}
-	err = client.GetJSON(ctx, "test", &result)
+	err = client.GetJSON(ctx, "test", nil, &result)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "context deadline exceeded")
@@ -339,7 +339,7 @@ func TestClient_WithNoRetries(t *testing.T) {
 	require.NoError(t, err)
 
 	var result map[string]interface{}
-	err = client.GetJSON(context.Background(), "test", &result)
+	err = client.GetJSON(context.Background(), "test", nil, &result)
 
 	assert.Error(t, err)
 	assert.Equal(t, 1, attemptCount) // Should only try once
@@ -360,7 +360,7 @@ func TestClient_WithMaxRetries(t *testing.T) {
 	require.NoError(t, err)
 
 	var result map[string]interface{}
-	err = client.GetJSON(context.Background(), "test", &result)
+	err = client.GetJSON(context.Background(), "test", nil, &result)
 
 	assert.Error(t, err)
 	assert.Equal(t, 2, attemptCount) // Should try 2 times total (1 initial + 1 retry)
@@ -550,7 +550,7 @@ func TestClient_RetryWithContextCancellationDuringBackoff(t *testing.T) {
 	defer cancel()
 
 	var result map[string]interface{}
-	err = client.GetJSON(ctx, "test", &result)
+	err = client.GetJSON(ctx, "test", nil, &result)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "context deadline exceeded")

--- a/client_test.go
+++ b/client_test.go
@@ -554,7 +554,7 @@ func TestGetJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	var result map[string]interface{}
-	err = client.GetJSON(t.Context(), "test", &result)
+	err = client.GetJSON(t.Context(), "test", nil, &result)
 
 	assert.NoError(t, err)
 	assert.Equal(t, float64(1), result["id"])

--- a/config/adfs_auth_server.go
+++ b/config/adfs_auth_server.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListADFSAuthServers(ctx context.Context, opts *ListOptions) (*ADFSAuthServerListResponse, error) {
 	endpoint := "configuration/v1/adfs_auth_server/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result ADFSAuthServerListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetADFSAuthServer(ctx context.Context, id int) (*ADFSAuthServe
 	endpoint := fmt.Sprintf("configuration/v1/adfs_auth_server/%d/", id)
 
 	var result ADFSAuthServer
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/adfs_auth_server_domain.go
+++ b/config/adfs_auth_server_domain.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListADFSAuthServerDomains(ctx context.Context, opts *ListOptions) (*ADFSAuthServerDomainListResponse, error) {
 	endpoint := "configuration/v1/adfs_auth_server_domain/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result ADFSAuthServerDomainListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetADFSAuthServerDomain(ctx context.Context, id int) (*ADFSAut
 	endpoint := fmt.Sprintf("configuration/v1/adfs_auth_server_domain/%d/", id)
 
 	var result ADFSAuthServerDomain
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/adfs_auth_server_domain_test.go
+++ b/config/adfs_auth_server_domain_test.go
@@ -33,8 +33,8 @@ func TestService_ListADFSAuthServerDomains(t *testing.T) {
 						{ID: 2, Domain: "subdomain.example.com", Description: "Subdomain", ADFSAuthServer: "/api/admin/configuration/v1/adfs_auth_server/1/"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/adfs_auth_server_domain/", mock.AnythingOfType("*config.ADFSAuthServerDomainListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ADFSAuthServerDomainListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/adfs_auth_server_domain/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ADFSAuthServerDomainListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ADFSAuthServerDomainListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListADFSAuthServerDomains(t *testing.T) {
 						{ID: 1, Domain: "example.com", Description: "Primary domain", ADFSAuthServer: "/api/admin/configuration/v1/adfs_auth_server/1/"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/adfs_auth_server_domain/?limit=5&name__icontains=example", mock.AnythingOfType("*config.ADFSAuthServerDomainListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ADFSAuthServerDomainListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/adfs_auth_server_domain/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ADFSAuthServerDomainListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ADFSAuthServerDomainListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -93,8 +93,8 @@ func TestService_GetADFSAuthServerDomain(t *testing.T) {
 		ADFSAuthServer: "/api/admin/configuration/v1/adfs_auth_server/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/adfs_auth_server_domain/1/", mock.AnythingOfType("*config.ADFSAuthServerDomain")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ADFSAuthServerDomain)
+	client.On("GetJSON", t.Context(), "configuration/v1/adfs_auth_server_domain/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ADFSAuthServerDomain")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ADFSAuthServerDomain)
 		*result = *expectedADFSAuthServerDomain
 	})
 

--- a/config/adfs_auth_server_test.go
+++ b/config/adfs_auth_server_test.go
@@ -33,8 +33,8 @@ func TestService_ListADFSAuthServers(t *testing.T) {
 						{ID: 2, Name: "backup-adfs", Description: "Backup ADFS server", ClientID: "client2", FederationServiceName: "fs2.example.com", FederationServiceIdentifier: "http://fs2.example.com/adfs/services/trust", RelyingPartyTrustIdentifierURL: "https://backup.example.com/"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/adfs_auth_server/", mock.AnythingOfType("*config.ADFSAuthServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ADFSAuthServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/adfs_auth_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ADFSAuthServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ADFSAuthServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListADFSAuthServers(t *testing.T) {
 						{ID: 1, Name: "primary-adfs", Description: "Primary ADFS server", ClientID: "client1", FederationServiceName: "fs.example.com", FederationServiceIdentifier: "http://fs.example.com/adfs/services/trust", RelyingPartyTrustIdentifierURL: "https://example.com/"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/adfs_auth_server/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.ADFSAuthServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ADFSAuthServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/adfs_auth_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ADFSAuthServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ADFSAuthServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -96,8 +96,8 @@ func TestService_GetADFSAuthServer(t *testing.T) {
 		RelyingPartyTrustIdentifierURL: "https://example.com/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/adfs_auth_server/1/", mock.AnythingOfType("*config.ADFSAuthServer")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ADFSAuthServer)
+	client.On("GetJSON", t.Context(), "configuration/v1/adfs_auth_server/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ADFSAuthServer")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ADFSAuthServer)
 		*result = *expectedADFSAuthServer
 	})
 

--- a/config/authentication.go
+++ b/config/authentication.go
@@ -15,7 +15,7 @@ func (s *Service) GetAuthentication(ctx context.Context) (*Authentication, error
 	endpoint := "configuration/v1/authentication/1/"
 
 	var result Authentication
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/authentication_test.go
+++ b/config/authentication_test.go
@@ -45,8 +45,8 @@ func TestService_GetAuthentication(t *testing.T) {
 		OidcScope:                 "",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/authentication/1/", mock.AnythingOfType("*config.Authentication")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*Authentication)
+	client.On("GetJSON", t.Context(), "configuration/v1/authentication/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.Authentication")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*Authentication)
 		*result = *expectedAuthentication
 	})
 

--- a/config/autobackup.go
+++ b/config/autobackup.go
@@ -15,7 +15,7 @@ func (s *Service) GetAutobackup(ctx context.Context) (*Autobackup, error) {
 	endpoint := "configuration/v1/autobackup/1/"
 
 	var result Autobackup
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/autobackup_test.go
+++ b/config/autobackup_test.go
@@ -27,8 +27,8 @@ func TestService_GetAutobackup(t *testing.T) {
 		AutobackupUploadPassword: "backuppass",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/autobackup/1/", mock.AnythingOfType("*config.Autobackup")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*Autobackup)
+	client.On("GetJSON", t.Context(), "configuration/v1/autobackup/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.Autobackup")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*Autobackup)
 		*result = *expectedAutobackup
 	})
 

--- a/config/automatic_participant.go
+++ b/config/automatic_participant.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListAutomaticParticipants(ctx context.Context, opts *ListOptions) (*AutomaticParticipantListResponse, error) {
 	endpoint := "configuration/v1/automatic_participant/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result AutomaticParticipantListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetAutomaticParticipant(ctx context.Context, id int) (*Automat
 	endpoint := fmt.Sprintf("configuration/v1/automatic_participant/%d/", id)
 
 	var result AutomaticParticipant
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/automatic_participant_test.go
+++ b/config/automatic_participant_test.go
@@ -33,8 +33,8 @@ func TestService_ListAutomaticParticipants(t *testing.T) {
 						{ID: 2, Alias: "auto-participant-2", Description: "Secondary participant", Conference: "/api/admin/configuration/v1/conference/2/", Protocol: "h323", CallType: "audio", Role: "guest", KeepConferenceAlive: "keep_conference_alive_if_multiple", Routing: "routing_rule", Streaming: true},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/automatic_participant/", mock.AnythingOfType("*config.AutomaticParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*AutomaticParticipantListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/automatic_participant/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.AutomaticParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*AutomaticParticipantListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListAutomaticParticipants(t *testing.T) {
 						{ID: 1, Alias: "auto-participant-1", Description: "Primary participant", Conference: "/api/admin/configuration/v1/conference/1/", Protocol: "sip", CallType: "video", Role: "chair", KeepConferenceAlive: "keep_conference_alive_never", Routing: "routing_rule", Streaming: false},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/automatic_participant/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.AutomaticParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*AutomaticParticipantListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/automatic_participant/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.AutomaticParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*AutomaticParticipantListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -104,8 +104,8 @@ func TestService_GetAutomaticParticipant(t *testing.T) {
 		PresentationURL:     "https://example.com/presentation.pdf",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/automatic_participant/1/", mock.AnythingOfType("*config.AutomaticParticipant")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*AutomaticParticipant)
+	client.On("GetJSON", t.Context(), "configuration/v1/automatic_participant/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.AutomaticParticipant")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*AutomaticParticipant)
 		*result = *expectedAutomaticParticipant
 	})
 

--- a/config/azure_tenant.go
+++ b/config/azure_tenant.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListAzureTenants(ctx context.Context, opts *ListOptions) (*AzureTenantListResponse, error) {
 	endpoint := "configuration/v1/azure_tenant/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result AzureTenantListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetAzureTenant(ctx context.Context, id int) (*AzureTenant, err
 	endpoint := fmt.Sprintf("configuration/v1/azure_tenant/%d/", id)
 
 	var result AzureTenant
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/azure_tenant_test.go
+++ b/config/azure_tenant_test.go
@@ -33,8 +33,8 @@ func TestService_ListAzureTenants(t *testing.T) {
 						{ID: 2, Name: "secondary-tenant", Description: "Secondary Teams tenant", TenantID: "87654321-4321-4321-4321-cba987654321"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/azure_tenant/", mock.AnythingOfType("*config.AzureTenantListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*AzureTenantListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/azure_tenant/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.AzureTenantListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*AzureTenantListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListAzureTenants(t *testing.T) {
 						{ID: 1, Name: "primary-tenant", Description: "Primary Teams tenant", TenantID: "12345678-1234-1234-1234-123456789abc"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/azure_tenant/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.AzureTenantListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*AzureTenantListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/azure_tenant/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.AzureTenantListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*AzureTenantListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -93,8 +93,8 @@ func TestService_GetAzureTenant(t *testing.T) {
 		TenantID:    "12345678-1234-1234-1234-123456789abc",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/azure_tenant/1/", mock.AnythingOfType("*config.AzureTenant")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*AzureTenant)
+	client.On("GetJSON", t.Context(), "configuration/v1/azure_tenant/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.AzureTenant")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*AzureTenant)
 		*result = *expectedAzureTenant
 	})
 

--- a/config/break_in_allow_list_address.go
+++ b/config/break_in_allow_list_address.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListBreakInAllowListAddresses(ctx context.Context, opts *ListOptions) (*BreakInAllowListAddressListResponse, error) {
 	endpoint := "configuration/v1/break_in_allow_list_address/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result BreakInAllowListAddressListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetBreakInAllowListAddress(ctx context.Context, id int) (*Brea
 	endpoint := fmt.Sprintf("configuration/v1/break_in_allow_list_address/%d/", id)
 
 	var result BreakInAllowListAddress
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/break_in_allow_list_address_test.go
+++ b/config/break_in_allow_list_address_test.go
@@ -33,8 +33,8 @@ func TestService_ListBreakInAllowListAddresses(t *testing.T) {
 						{ID: 2, Name: "vpn-range", Description: "VPN IP range", Address: "10.0.0.0", Prefix: 16, AllowlistEntryType: "alias_only", IgnoreIncorrectAliases: false, IgnoreIncorrectPins: true},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/break_in_allow_list_address/", mock.AnythingOfType("*config.BreakInAllowListAddressListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*BreakInAllowListAddressListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/break_in_allow_list_address/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.BreakInAllowListAddressListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*BreakInAllowListAddressListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListBreakInAllowListAddresses(t *testing.T) {
 						{ID: 1, Name: "corporate-network", Description: "Corporate network range", Address: "192.168.1.0", Prefix: 24, AllowlistEntryType: "all", IgnoreIncorrectAliases: true, IgnoreIncorrectPins: false},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/break_in_allow_list_address/?limit=5&name__icontains=corporate", mock.AnythingOfType("*config.BreakInAllowListAddressListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*BreakInAllowListAddressListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/break_in_allow_list_address/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.BreakInAllowListAddressListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*BreakInAllowListAddressListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -97,8 +97,8 @@ func TestService_GetBreakInAllowListAddress(t *testing.T) {
 		IgnoreIncorrectPins:    false,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/break_in_allow_list_address/1/", mock.AnythingOfType("*config.BreakInAllowListAddress")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*BreakInAllowListAddress)
+	client.On("GetJSON", t.Context(), "configuration/v1/break_in_allow_list_address/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.BreakInAllowListAddress")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*BreakInAllowListAddress)
 		*result = *expectedBreakInAllowListAddress
 	})
 

--- a/config/ca_certificate.go
+++ b/config/ca_certificate.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListCACertificates(ctx context.Context, opts *ListOptions) (*CACertificateListResponse, error) {
 	endpoint := "configuration/v1/ca_certificate/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result CACertificateListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetCACertificate(ctx context.Context, id int) (*CACertificate,
 	endpoint := fmt.Sprintf("configuration/v1/ca_certificate/%d/", id)
 
 	var result CACertificate
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/ca_certificate_test.go
+++ b/config/ca_certificate_test.go
@@ -33,8 +33,8 @@ func TestService_ListCACertificates(t *testing.T) {
 						{ID: 2, Certificate: "-----BEGIN CERTIFICATE-----\nMIICertificate2\n-----END CERTIFICATE-----", TrustedIntermediate: false, SubjectName: "CN=Root CA 2", IssuerName: "CN=Root CA 2"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ca_certificate/", mock.AnythingOfType("*config.CACertificateListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*CACertificateListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ca_certificate/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.CACertificateListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*CACertificateListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListCACertificates(t *testing.T) {
 						{ID: 1, Certificate: "-----BEGIN CERTIFICATE-----\nMIICertificate1\n-----END CERTIFICATE-----", TrustedIntermediate: true, SubjectName: "CN=Root CA 1", IssuerName: "CN=Root CA 1"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ca_certificate/?limit=5&name__icontains=RootCA", mock.AnythingOfType("*config.CACertificateListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*CACertificateListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ca_certificate/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.CACertificateListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*CACertificateListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -104,8 +104,8 @@ func TestService_GetCACertificate(t *testing.T) {
 		Text:                "Certificate details...",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/ca_certificate/1/", mock.AnythingOfType("*config.CACertificate")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*CACertificate)
+	client.On("GetJSON", t.Context(), "configuration/v1/ca_certificate/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.CACertificate")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*CACertificate)
 		*result = *expectedCACertificate
 	})
 

--- a/config/certificate_signing_request.go
+++ b/config/certificate_signing_request.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListCertificateSigningRequests(ctx context.Context, opts *ListOptions) (*CertificateSigningRequestListResponse, error) {
 	endpoint := "configuration/v1/certificate_signing_request/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result CertificateSigningRequestListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetCertificateSigningRequest(ctx context.Context, id int) (*Ce
 	endpoint := fmt.Sprintf("configuration/v1/certificate_signing_request/%d/", id)
 
 	var result CertificateSigningRequest
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/certificate_signing_request_test.go
+++ b/config/certificate_signing_request_test.go
@@ -37,8 +37,8 @@ func TestService_ListCertificateSigningRequests(t *testing.T) {
 						{ID: 2, SubjectName: "CN=test.example.com", DN: "CN=test.example.com,O=Test Org,C=US", PrivateKeyType: "rsa_4096", PrivateKey: &privateKey2, AdCompatible: true, TLSCertificate: &tlsCert2, CSR: "-----BEGIN CERTIFICATE REQUEST-----\nMIICSR2\n-----END CERTIFICATE REQUEST-----"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/certificate_signing_request/", mock.AnythingOfType("*config.CertificateSigningRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*CertificateSigningRequestListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/certificate_signing_request/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.CertificateSigningRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*CertificateSigningRequestListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -60,8 +60,8 @@ func TestService_ListCertificateSigningRequests(t *testing.T) {
 						{ID: 1, SubjectName: "CN=example.com", DN: "CN=example.com,O=Test Org,C=US", PrivateKeyType: "rsa_2048", PrivateKey: &privateKey, AdCompatible: false, TLSCertificate: &tlsCert, CSR: "-----BEGIN CERTIFICATE REQUEST-----\nMIICSR1\n-----END CERTIFICATE REQUEST-----"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/certificate_signing_request/?limit=5&name__icontains=example.com", mock.AnythingOfType("*config.CertificateSigningRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*CertificateSigningRequestListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/certificate_signing_request/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.CertificateSigningRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*CertificateSigningRequestListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -108,8 +108,8 @@ func TestService_GetCertificateSigningRequest(t *testing.T) {
 		Certificate:               "-----BEGIN CERTIFICATE-----\nMIITestCertificate\n-----END CERTIFICATE-----",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/certificate_signing_request/1/", mock.AnythingOfType("*config.CertificateSigningRequest")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*CertificateSigningRequest)
+	client.On("GetJSON", t.Context(), "configuration/v1/certificate_signing_request/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.CertificateSigningRequest")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*CertificateSigningRequest)
 		*result = *expectedCertificateSigningRequest
 	})
 

--- a/config/conference.go
+++ b/config/conference.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListConferences(ctx context.Context, opts *ListOptions) (*ConferenceListResponse, error) {
 	endpoint := "configuration/v1/conference/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result ConferenceListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetConference(ctx context.Context, id int) (*Conference, error
 	endpoint := fmt.Sprintf("configuration/v1/conference/%d/", id)
 
 	var result Conference
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/conference_alias.go
+++ b/config/conference_alias.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListConferenceAliases(ctx context.Context, opts *ListOptions) (*ConferenceAliasListResponse, error) {
 	endpoint := "configuration/v1/conference_alias/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result ConferenceAliasListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetConferenceAlias(ctx context.Context, id int) (*ConferenceAl
 	endpoint := fmt.Sprintf("configuration/v1/conference_alias/%d/", id)
 
 	var result ConferenceAlias
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/conference_alias_test.go
+++ b/config/conference_alias_test.go
@@ -35,8 +35,8 @@ func TestService_ListConferenceAliases(t *testing.T) {
 						{ID: 2, Alias: "another-alias", Conference: "/api/admin/configuration/v1/conference/2/"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/conference_alias/", mock.AnythingOfType("*config.ConferenceAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ConferenceAliasListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/conference_alias/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ConferenceAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ConferenceAliasListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -57,8 +57,8 @@ func TestService_ListConferenceAliases(t *testing.T) {
 						{ID: 1, Alias: "test-alias", Conference: "/api/admin/configuration/v1/conference/1/"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/conference_alias/?limit=5&name__icontains=test&offset=10", mock.AnythingOfType("*config.ConferenceAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ConferenceAliasListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/conference_alias/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ConferenceAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ConferenceAliasListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -97,8 +97,8 @@ func TestService_GetConferenceAlias(t *testing.T) {
 		CreationTime: util.InfinityTime{Time: time.Now()},
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/conference_alias/1/", mock.AnythingOfType("*config.ConferenceAlias")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ConferenceAlias)
+	client.On("GetJSON", t.Context(), "configuration/v1/conference_alias/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ConferenceAlias")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ConferenceAlias)
 		*result = *expectedAlias
 	})
 

--- a/config/conference_sync_template.go
+++ b/config/conference_sync_template.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListConferenceSyncTemplates(ctx context.Context, opts *ListOptions) (*ConferenceSyncTemplateListResponse, error) {
 	endpoint := "configuration/v1/conference_sync_template/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result ConferenceSyncTemplateListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetConferenceSyncTemplate(ctx context.Context, id int) (*Confe
 	endpoint := fmt.Sprintf("configuration/v1/conference_sync_template/%d/", id)
 
 	var result ConferenceSyncTemplate
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/conference_sync_template_test.go
+++ b/config/conference_sync_template_test.go
@@ -33,8 +33,8 @@ func TestService_ListConferenceSyncTemplates(t *testing.T) {
 						{ID: 2, Name: "secondary-template", Description: "Secondary sync template", LdapUserFilter: "(objectClass=person)", EnableAutomaticSync: false, SyncConferences: false, SyncDevices: true, SyncEndUsers: false, ServiceType: "virtual_meeting_room", CallType: "audio", AllowGuests: false},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/conference_sync_template/", mock.AnythingOfType("*config.ConferenceSyncTemplateListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ConferenceSyncTemplateListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/conference_sync_template/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ConferenceSyncTemplateListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ConferenceSyncTemplateListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListConferenceSyncTemplates(t *testing.T) {
 						{ID: 1, Name: "primary-template", Description: "Primary sync template", LdapUserFilter: "(objectClass=user)", EnableAutomaticSync: true, SyncConferences: true, SyncDevices: false, SyncEndUsers: true, ServiceType: "conference", CallType: "video", AllowGuests: true},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/conference_sync_template/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.ConferenceSyncTemplateListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ConferenceSyncTemplateListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/conference_sync_template/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ConferenceSyncTemplateListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ConferenceSyncTemplateListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -165,8 +165,8 @@ func TestService_GetConferenceSyncTemplate(t *testing.T) {
 		EndUserAdvancedOverridable:          false,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/conference_sync_template/1/", mock.AnythingOfType("*config.ConferenceSyncTemplate")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ConferenceSyncTemplate)
+	client.On("GetJSON", t.Context(), "configuration/v1/conference_sync_template/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ConferenceSyncTemplate")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ConferenceSyncTemplate)
 		*result = *expectedConferenceSyncTemplate
 	})
 

--- a/config/conference_test.go
+++ b/config/conference_test.go
@@ -34,8 +34,8 @@ func TestService_ListConferences(t *testing.T) {
 						{ID: 2, Name: "Test Conference 2"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/conference/", mock.AnythingOfType("*config.ConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ConferenceListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/conference/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ConferenceListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -56,8 +56,8 @@ func TestService_ListConferences(t *testing.T) {
 						{ID: 1, Name: "Test Conference"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/conference/?limit=10&name__icontains=test&offset=5", mock.AnythingOfType("*config.ConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ConferenceListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/conference/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ConferenceListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -93,8 +93,8 @@ func TestService_GetConference(t *testing.T) {
 		Name: "Test Conference",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/conference/1/", mock.AnythingOfType("*config.Conference")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*Conference)
+	client.On("GetJSON", t.Context(), "configuration/v1/conference/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.Conference")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*Conference)
 		*result = *expectedConference
 	})
 
@@ -183,7 +183,7 @@ func TestService_ListConferences_QueryParameterValidation(t *testing.T) {
 				BaseListOptions: options.BaseListOptions{Limit: 10},
 				Search:          "",
 			},
-			expectedQuery: "configuration/v1/conference/?limit=10",
+			expectedQuery: "configuration/v1/conference/",
 		},
 		{
 			name: "search with special characters",
@@ -191,7 +191,7 @@ func TestService_ListConferences_QueryParameterValidation(t *testing.T) {
 				BaseListOptions: options.BaseListOptions{Limit: 5},
 				Search:          "test@domain.com",
 			},
-			expectedQuery: "configuration/v1/conference/?limit=5&name__icontains=test%40domain.com",
+			expectedQuery: "configuration/v1/conference/",
 		},
 		{
 			name: "unicode search",
@@ -199,7 +199,7 @@ func TestService_ListConferences_QueryParameterValidation(t *testing.T) {
 				BaseListOptions: options.BaseListOptions{Limit: 5},
 				Search:          "cönférence",
 			},
-			expectedQuery: "configuration/v1/conference/?limit=5&name__icontains=c%C3%B6nf%C3%A9rence",
+			expectedQuery: "configuration/v1/conference/",
 		},
 	}
 
@@ -208,8 +208,8 @@ func TestService_ListConferences_QueryParameterValidation(t *testing.T) {
 			client := interfaces.NewHTTPClientMock()
 			expectedResponse := &ConferenceListResponse{Objects: []Conference{}}
 
-			client.On("GetJSON", t.Context(), tt.expectedQuery, mock.AnythingOfType("*config.ConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
-				result := args.Get(2).(*ConferenceListResponse)
+			client.On("GetJSON", t.Context(), tt.expectedQuery, mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
+				result := args.Get(3).(*ConferenceListResponse)
 				*result = *expectedResponse
 			})
 
@@ -231,7 +231,7 @@ func TestService_ConferenceErrorHandling(t *testing.T) {
 		{
 			name: "ListConferences client error",
 			setup: func(m *interfaces.HTTPClientMock) {
-				m.On("GetJSON", t.Context(), "configuration/v1/conference/", mock.AnythingOfType("*config.ConferenceListResponse")).Return(errors.New("network error"))
+				m.On("GetJSON", t.Context(), "configuration/v1/conference/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ConferenceListResponse")).Return(errors.New("network error"))
 			},
 			operation: func(service *Service) error {
 				_, err := service.ListConferences(t.Context(), nil)
@@ -241,7 +241,7 @@ func TestService_ConferenceErrorHandling(t *testing.T) {
 		{
 			name: "GetConference client error",
 			setup: func(m *interfaces.HTTPClientMock) {
-				m.On("GetJSON", t.Context(), "configuration/v1/conference/1/", mock.AnythingOfType("*config.Conference")).Return(errors.New("not found"))
+				m.On("GetJSON", t.Context(), "configuration/v1/conference/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.Conference")).Return(errors.New("not found"))
 			},
 			operation: func(service *Service) error {
 				_, err := service.GetConference(t.Context(), 1)

--- a/config/device.go
+++ b/config/device.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListDevices(ctx context.Context, opts *ListOptions) (*DeviceListResponse, error) {
 	endpoint := "configuration/v1/device/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result DeviceListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetDevice(ctx context.Context, id int) (*Device, error) {
 	endpoint := fmt.Sprintf("configuration/v1/device/%d/", id)
 
 	var result Device
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/device_test.go
+++ b/config/device_test.go
@@ -33,8 +33,8 @@ func TestService_ListDevices(t *testing.T) {
 						{ID: 2, Alias: "device2", Description: "Test device 2", EnableH323: true},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/device/", mock.AnythingOfType("*config.DeviceListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*DeviceListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/device/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.DeviceListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*DeviceListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListDevices(t *testing.T) {
 						{ID: 1, Alias: "device1", Description: "Test device 1", EnableSIP: true},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/device/?limit=5&name__icontains=device1", mock.AnythingOfType("*config.DeviceListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*DeviceListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/device/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.DeviceListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*DeviceListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -101,8 +101,8 @@ func TestService_GetDevice(t *testing.T) {
 		Tag:                         "test-tag",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/device/1/", mock.AnythingOfType("*config.Device")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*Device)
+	client.On("GetJSON", t.Context(), "configuration/v1/device/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.Device")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*Device)
 		*result = *expectedDevice
 	})
 

--- a/config/diagnostic_graphs.go
+++ b/config/diagnostic_graphs.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListDiagnosticGraphs(ctx context.Context, opts *ListOptions) (*DiagnosticGraphListResponse, error) {
 	endpoint := "configuration/v1/diagnostic_graphs/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result DiagnosticGraphListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetDiagnosticGraph(ctx context.Context, id int) (*DiagnosticGr
 	endpoint := fmt.Sprintf("configuration/v1/diagnostic_graphs/%d/", id)
 
 	var result DiagnosticGraph
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/diagnostic_graphs_test.go
+++ b/config/diagnostic_graphs_test.go
@@ -33,8 +33,8 @@ func TestService_ListDiagnosticGraphs(t *testing.T) {
 						{ID: 2, Title: "Memory Usage", Order: 2, Datasets: []string{"memory_used", "memory_free"}},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/diagnostic_graphs/", mock.AnythingOfType("*config.DiagnosticGraphListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*DiagnosticGraphListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/diagnostic_graphs/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.DiagnosticGraphListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*DiagnosticGraphListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListDiagnosticGraphs(t *testing.T) {
 						{ID: 1, Title: "CPU Usage", Order: 1, Datasets: []string{"cpu_usage", "cpu_idle"}},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/diagnostic_graphs/?limit=5&name__icontains=CPU", mock.AnythingOfType("*config.DiagnosticGraphListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*DiagnosticGraphListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/diagnostic_graphs/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.DiagnosticGraphListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*DiagnosticGraphListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -93,8 +93,8 @@ func TestService_GetDiagnosticGraph(t *testing.T) {
 		Datasets: []string{"network_in", "network_out", "packet_loss"},
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/diagnostic_graphs/1/", mock.AnythingOfType("*config.DiagnosticGraph")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*DiagnosticGraph)
+	client.On("GetJSON", t.Context(), "configuration/v1/diagnostic_graphs/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.DiagnosticGraph")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*DiagnosticGraph)
 		*result = *expectedDiagnosticGraph
 	})
 

--- a/config/dns_server.go
+++ b/config/dns_server.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListDNSServers(ctx context.Context, opts *ListOptions) (*DNSServerListResponse, error) {
 	endpoint := "configuration/v1/dns_server/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result DNSServerListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetDNSServer(ctx context.Context, id int) (*DNSServer, error) 
 	endpoint := fmt.Sprintf("configuration/v1/dns_server/%d/", id)
 
 	var result DNSServer
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/dns_server_test.go
+++ b/config/dns_server_test.go
@@ -33,8 +33,8 @@ func TestService_ListDNSServers(t *testing.T) {
 						{ID: 2, Address: "1.1.1.1", Description: "Cloudflare DNS"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/dns_server/", mock.AnythingOfType("*config.DNSServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*DNSServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/dns_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.DNSServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*DNSServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListDNSServers(t *testing.T) {
 						{ID: 1, Address: "8.8.8.8", Description: "Google DNS"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/dns_server/?limit=5&name__icontains=google", mock.AnythingOfType("*config.DNSServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*DNSServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/dns_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.DNSServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*DNSServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -92,8 +92,8 @@ func TestService_GetDNSServer(t *testing.T) {
 		Description: "Google DNS Server",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/dns_server/1/", mock.AnythingOfType("*config.DNSServer")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*DNSServer)
+	client.On("GetJSON", t.Context(), "configuration/v1/dns_server/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.DNSServer")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*DNSServer)
 		*result = *expectedServer
 	})
 

--- a/config/end_user.go
+++ b/config/end_user.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListEndUsers(ctx context.Context, opts *ListOptions) (*EndUserListResponse, error) {
 	endpoint := "configuration/v1/end_user/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result EndUserListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetEndUser(ctx context.Context, id int) (*EndUser, error) {
 	endpoint := fmt.Sprintf("configuration/v1/end_user/%d/", id)
 
 	var result EndUser
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/end_user_test.go
+++ b/config/end_user_test.go
@@ -33,8 +33,8 @@ func TestService_ListEndUsers(t *testing.T) {
 						{ID: 2, PrimaryEmailAddress: "user2@example.com", FirstName: "Jane", LastName: "Smith"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/end_user/", mock.AnythingOfType("*config.EndUserListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*EndUserListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/end_user/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.EndUserListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*EndUserListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -55,8 +55,8 @@ func TestService_ListEndUsers(t *testing.T) {
 						{ID: 1, PrimaryEmailAddress: "john@example.com", FirstName: "John", LastName: "Doe"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/end_user/?limit=5&name__icontains=john&offset=10", mock.AnythingOfType("*config.EndUserListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*EndUserListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/end_user/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.EndUserListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*EndUserListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -96,8 +96,8 @@ func TestService_GetEndUser(t *testing.T) {
 		TelephoneNumber:     "+1234567890",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/end_user/1/", mock.AnythingOfType("*config.EndUser")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*EndUser)
+	client.On("GetJSON", t.Context(), "configuration/v1/end_user/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.EndUser")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*EndUser)
 		*result = *expectedUser
 	})
 

--- a/config/event_sink.go
+++ b/config/event_sink.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListEventSinks(ctx context.Context, opts *ListOptions) (*EventSinkListResponse, error) {
 	endpoint := "configuration/v1/event_sink/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result EventSinkListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetEventSink(ctx context.Context, id int) (*EventSink, error) 
 	endpoint := fmt.Sprintf("configuration/v1/event_sink/%d/", id)
 
 	var result EventSink
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/event_sink_test.go
+++ b/config/event_sink_test.go
@@ -35,8 +35,8 @@ func TestService_ListEventSinks(t *testing.T) {
 						{ID: 2, Name: "secondary-sink", Description: &desc2, URL: "https://backup.example.com/events", BulkSupport: false, VerifyTLSCertificate: true, Version: 2},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/event_sink/", mock.AnythingOfType("*config.EventSinkListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*EventSinkListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/event_sink/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.EventSinkListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*EventSinkListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -57,8 +57,8 @@ func TestService_ListEventSinks(t *testing.T) {
 						{ID: 1, Name: "primary-sink", Description: &desc, URL: "https://events.example.com/webhook", BulkSupport: true, VerifyTLSCertificate: true, Version: 2},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/event_sink/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.EventSinkListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*EventSinkListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/event_sink/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.EventSinkListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*EventSinkListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -105,8 +105,8 @@ func TestService_GetEventSink(t *testing.T) {
 		Version:              2,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/event_sink/1/", mock.AnythingOfType("*config.EventSink")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*EventSink)
+	client.On("GetJSON", t.Context(), "configuration/v1/event_sink/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.EventSink")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*EventSink)
 		*result = *expectedEventSink
 	})
 

--- a/config/exchange_domain.go
+++ b/config/exchange_domain.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListExchangeDomains(ctx context.Context, opts *ListOptions) (*ExchangeDomainListResponse, error) {
 	endpoint := "configuration/v1/exchange_domain/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result ExchangeDomainListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetExchangeDomain(ctx context.Context, id int) (*ExchangeDomai
 	endpoint := fmt.Sprintf("configuration/v1/exchange_domain/%d/", id)
 
 	var result ExchangeDomain
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/exchange_domain_test.go
+++ b/config/exchange_domain_test.go
@@ -33,8 +33,8 @@ func TestService_ListExchangeDomains(t *testing.T) {
 						{ID: 2, Domain: "subdomain.example.com", ExchangeConnector: "/api/admin/configuration/v1/exchange_connector/2/"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/exchange_domain/", mock.AnythingOfType("*config.ExchangeDomainListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ExchangeDomainListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/exchange_domain/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ExchangeDomainListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ExchangeDomainListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListExchangeDomains(t *testing.T) {
 						{ID: 1, Domain: "example.com", ExchangeConnector: "/api/admin/configuration/v1/exchange_connector/1/"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/exchange_domain/?limit=5&name__icontains=example", mock.AnythingOfType("*config.ExchangeDomainListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ExchangeDomainListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/exchange_domain/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ExchangeDomainListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ExchangeDomainListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -92,8 +92,8 @@ func TestService_GetExchangeDomain(t *testing.T) {
 		ExchangeConnector: "/api/admin/configuration/v1/exchange_connector/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/exchange_domain/1/", mock.AnythingOfType("*config.ExchangeDomain")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ExchangeDomain)
+	client.On("GetJSON", t.Context(), "configuration/v1/exchange_domain/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ExchangeDomain")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ExchangeDomain)
 		*result = *expectedExchangeDomain
 	})
 

--- a/config/external_webapp_host.go
+++ b/config/external_webapp_host.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListExternalWebappHosts(ctx context.Context, opts *ListOptions) (*ExternalWebappHostListResponse, error) {
 	endpoint := "configuration/v1/external_webapp_host/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result ExternalWebappHostListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetExternalWebappHost(ctx context.Context, id int) (*ExternalW
 	endpoint := fmt.Sprintf("configuration/v1/external_webapp_host/%d/", id)
 
 	var result ExternalWebappHost
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/external_webapp_host_test.go
+++ b/config/external_webapp_host_test.go
@@ -33,8 +33,8 @@ func TestService_ListExternalWebappHosts(t *testing.T) {
 						{ID: 2, Address: "webapp2.example.com"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/external_webapp_host/", mock.AnythingOfType("*config.ExternalWebappHostListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ExternalWebappHostListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/external_webapp_host/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ExternalWebappHostListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ExternalWebappHostListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListExternalWebappHosts(t *testing.T) {
 						{ID: 1, Address: "webapp1.example.com"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/external_webapp_host/?limit=5&name__icontains=webapp1", mock.AnythingOfType("*config.ExternalWebappHostListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ExternalWebappHostListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/external_webapp_host/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ExternalWebappHostListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ExternalWebappHostListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -91,8 +91,8 @@ func TestService_GetExternalWebappHost(t *testing.T) {
 		Address: "test-webapp.example.com",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/external_webapp_host/1/", mock.AnythingOfType("*config.ExternalWebappHost")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ExternalWebappHost)
+	client.On("GetJSON", t.Context(), "configuration/v1/external_webapp_host/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ExternalWebappHost")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ExternalWebappHost)
 		*result = *expectedExternalWebappHost
 	})
 

--- a/config/gateway_routing_rule.go
+++ b/config/gateway_routing_rule.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListGatewayRoutingRules(ctx context.Context, opts *ListOptions) (*GatewayRoutingRuleListResponse, error) {
 	endpoint := "configuration/v1/gateway_routing_rule/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result GatewayRoutingRuleListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetGatewayRoutingRule(ctx context.Context, id int) (*GatewayRo
 	endpoint := fmt.Sprintf("configuration/v1/gateway_routing_rule/%d/", id)
 
 	var result GatewayRoutingRule
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/gateway_routing_rule_test.go
+++ b/config/gateway_routing_rule_test.go
@@ -35,8 +35,8 @@ func TestService_ListGatewayRoutingRules(t *testing.T) {
 						{ID: 2, Name: "secondary-rule", Description: "Secondary routing rule", Priority: 200, Enable: false, MatchString: "test@.*", MatchStringFull: true, CalledDeviceType: "internal", OutgoingProtocol: "h323", CallType: "audio", MatchIncomingCalls: false, MatchOutgoingCalls: true, MatchIncomingH323: true, TreatAsTrusted: true},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/gateway_routing_rule/", mock.AnythingOfType("*config.GatewayRoutingRuleListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*GatewayRoutingRuleListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/gateway_routing_rule/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.GatewayRoutingRuleListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*GatewayRoutingRuleListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -58,8 +58,8 @@ func TestService_ListGatewayRoutingRules(t *testing.T) {
 						{ID: 1, Name: "primary-rule", Description: "Primary routing rule", Priority: 100, Enable: true, MatchString: ".*", MatchStringFull: false, CalledDeviceType: "external", OutgoingProtocol: "sip", CallType: "video", MatchIncomingCalls: true, MatchOutgoingCalls: false, MatchIncomingSIP: true, SIPProxy: &sipProxy, OutgoingLocation: &location, TreatAsTrusted: false},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/gateway_routing_rule/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.GatewayRoutingRuleListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*GatewayRoutingRuleListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/gateway_routing_rule/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.GatewayRoutingRuleListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*GatewayRoutingRuleListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -133,8 +133,8 @@ func TestService_GetGatewayRoutingRule(t *testing.T) {
 		DisabledCodecs:                []string{"h264", "vp8"},
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/gateway_routing_rule/1/", mock.AnythingOfType("*config.GatewayRoutingRule")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*GatewayRoutingRule)
+	client.On("GetJSON", t.Context(), "configuration/v1/gateway_routing_rule/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.GatewayRoutingRule")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*GatewayRoutingRule)
 		*result = *expectedGatewayRoutingRule
 	})
 

--- a/config/global_configuration.go
+++ b/config/global_configuration.go
@@ -15,7 +15,7 @@ func (s *Service) GetGlobalConfiguration(ctx context.Context) (*GlobalConfigurat
 	endpoint := "configuration/v1/global/1/"
 
 	var result GlobalConfiguration
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/global_configuration_test.go
+++ b/config/global_configuration_test.go
@@ -36,8 +36,8 @@ func TestService_GetGlobalConfiguration(t *testing.T) {
 		AdministratorEmail:     "admin@example.com",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/global/1/", mock.AnythingOfType("*config.GlobalConfiguration")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*GlobalConfiguration)
+	client.On("GetJSON", t.Context(), "configuration/v1/global/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.GlobalConfiguration")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*GlobalConfiguration)
 		*result = *expectedConfig
 	})
 

--- a/config/gms_access_token.go
+++ b/config/gms_access_token.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListGMSAccessTokens(ctx context.Context, opts *ListOptions) (*GMSAccessTokenListResponse, error) {
 	endpoint := "configuration/v1/gms_access_token/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result GMSAccessTokenListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetGMSAccessToken(ctx context.Context, id int) (*GMSAccessToke
 	endpoint := fmt.Sprintf("configuration/v1/gms_access_token/%d/", id)
 
 	var result GMSAccessToken
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/gms_access_token_test.go
+++ b/config/gms_access_token_test.go
@@ -33,8 +33,8 @@ func TestService_ListGMSAccessTokens(t *testing.T) {
 						{ID: 2, Name: "secondary-gms-token", Token: "token2"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/gms_access_token/", mock.AnythingOfType("*config.GMSAccessTokenListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*GMSAccessTokenListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/gms_access_token/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.GMSAccessTokenListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*GMSAccessTokenListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListGMSAccessTokens(t *testing.T) {
 						{ID: 1, Name: "primary-gms-token", Token: "token1"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/gms_access_token/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.GMSAccessTokenListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*GMSAccessTokenListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/gms_access_token/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.GMSAccessTokenListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*GMSAccessTokenListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -92,8 +92,8 @@ func TestService_GetGMSAccessToken(t *testing.T) {
 		Token: "test-token-value",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/gms_access_token/1/", mock.AnythingOfType("*config.GMSAccessToken")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*GMSAccessToken)
+	client.On("GetJSON", t.Context(), "configuration/v1/gms_access_token/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.GMSAccessToken")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*GMSAccessToken)
 		*result = *expectedGMSAccessToken
 	})
 

--- a/config/gms_gateway_token.go
+++ b/config/gms_gateway_token.go
@@ -15,7 +15,7 @@ func (s *Service) GetGMSGatewayToken(ctx context.Context) (*GMSGatewayToken, err
 	endpoint := "configuration/v1/gms_gateway_token/1/"
 
 	var result GMSGatewayToken
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/gms_gateway_token_test.go
+++ b/config/gms_gateway_token_test.go
@@ -31,8 +31,8 @@ func TestService_GetGMSGatewayToken(t *testing.T) {
 		ResourceURI:             "/api/admin/configuration/v1/gms_gateway_token/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/gms_gateway_token/1/", mock.AnythingOfType("*config.GMSGatewayToken")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*GMSGatewayToken)
+	client.On("GetJSON", t.Context(), "configuration/v1/gms_gateway_token/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.GMSGatewayToken")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*GMSGatewayToken)
 		*result = *expectedToken
 	})
 

--- a/config/google_auth_server.go
+++ b/config/google_auth_server.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListGoogleAuthServers(ctx context.Context, opts *ListOptions) (*GoogleAuthServerListResponse, error) {
 	endpoint := "configuration/v1/google_auth_server/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result GoogleAuthServerListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetGoogleAuthServer(ctx context.Context, id int) (*GoogleAuthS
 	endpoint := fmt.Sprintf("configuration/v1/google_auth_server/%d/", id)
 
 	var result GoogleAuthServer
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/google_auth_server_domain.go
+++ b/config/google_auth_server_domain.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListGoogleAuthServerDomains(ctx context.Context, opts *ListOptions) (*GoogleAuthServerDomainListResponse, error) {
 	endpoint := "configuration/v1/google_auth_server_domain/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result GoogleAuthServerDomainListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetGoogleAuthServerDomain(ctx context.Context, id int) (*Googl
 	endpoint := fmt.Sprintf("configuration/v1/google_auth_server_domain/%d/", id)
 
 	var result GoogleAuthServerDomain
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/google_auth_server_domain_test.go
+++ b/config/google_auth_server_domain_test.go
@@ -33,8 +33,8 @@ func TestService_ListGoogleAuthServerDomains(t *testing.T) {
 						{ID: 2, Domain: "test.com", Description: "Test domain", GoogleAuthServer: "/api/admin/configuration/v1/google_auth_server/2/"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/google_auth_server_domain/", mock.AnythingOfType("*config.GoogleAuthServerDomainListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*GoogleAuthServerDomainListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/google_auth_server_domain/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.GoogleAuthServerDomainListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*GoogleAuthServerDomainListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListGoogleAuthServerDomains(t *testing.T) {
 						{ID: 1, Domain: "example.com", Description: "Primary domain", GoogleAuthServer: "/api/admin/configuration/v1/google_auth_server/1/"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/google_auth_server_domain/?limit=5&name__icontains=example", mock.AnythingOfType("*config.GoogleAuthServerDomainListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*GoogleAuthServerDomainListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/google_auth_server_domain/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.GoogleAuthServerDomainListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*GoogleAuthServerDomainListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -94,8 +94,8 @@ func TestService_GetGoogleAuthServerDomain(t *testing.T) {
 		ResourceURI:      "/api/admin/configuration/v1/google_auth_server_domain/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/google_auth_server_domain/1/", mock.AnythingOfType("*config.GoogleAuthServerDomain")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*GoogleAuthServerDomain)
+	client.On("GetJSON", t.Context(), "configuration/v1/google_auth_server_domain/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.GoogleAuthServerDomain")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*GoogleAuthServerDomain)
 		*result = *expectedDomain
 	})
 

--- a/config/google_auth_server_test.go
+++ b/config/google_auth_server_test.go
@@ -35,8 +35,8 @@ func TestService_ListGoogleAuthServers(t *testing.T) {
 						{ID: 2, Name: "backup-google-auth", Description: "Backup Google OAuth server", ApplicationType: "web", ClientID: &clientID2, ClientSecret: "secret2"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/google_auth_server/", mock.AnythingOfType("*config.GoogleAuthServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*GoogleAuthServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/google_auth_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.GoogleAuthServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*GoogleAuthServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -57,8 +57,8 @@ func TestService_ListGoogleAuthServers(t *testing.T) {
 						{ID: 1, Name: "primary-google-auth", Description: "Primary Google OAuth server", ApplicationType: "web", ClientID: &clientID, ClientSecret: "secret1"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/google_auth_server/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.GoogleAuthServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*GoogleAuthServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/google_auth_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.GoogleAuthServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*GoogleAuthServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -100,8 +100,8 @@ func TestService_GetGoogleAuthServer(t *testing.T) {
 		ResourceURI:     "/api/admin/configuration/v1/google_auth_server/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/google_auth_server/1/", mock.AnythingOfType("*config.GoogleAuthServer")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*GoogleAuthServer)
+	client.On("GetJSON", t.Context(), "configuration/v1/google_auth_server/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.GoogleAuthServer")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*GoogleAuthServer)
 		*result = *expectedServer
 	})
 

--- a/config/h323_gatekeeper.go
+++ b/config/h323_gatekeeper.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListH323Gatekeepers(ctx context.Context, opts *ListOptions) (*H323GatekeeperListResponse, error) {
 	endpoint := "configuration/v1/h323_gatekeeper/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result H323GatekeeperListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetH323Gatekeeper(ctx context.Context, id int) (*H323Gatekeepe
 	endpoint := fmt.Sprintf("configuration/v1/h323_gatekeeper/%d/", id)
 
 	var result H323Gatekeeper
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/h323_gatekeeper_test.go
+++ b/config/h323_gatekeeper_test.go
@@ -34,8 +34,8 @@ func TestService_ListH323Gatekeepers(t *testing.T) {
 						{ID: 2, Name: "backup-gk", Description: "Backup H.323 gatekeeper", Address: "backup-gk.example.com", Port: &port},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/h323_gatekeeper/", mock.AnythingOfType("*config.H323GatekeeperListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*H323GatekeeperListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/h323_gatekeeper/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.H323GatekeeperListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*H323GatekeeperListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -56,8 +56,8 @@ func TestService_ListH323Gatekeepers(t *testing.T) {
 						{ID: 1, Name: "primary-gk", Description: "Primary H.323 gatekeeper", Address: "gk.example.com", Port: &port},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/h323_gatekeeper/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.H323GatekeeperListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*H323GatekeeperListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/h323_gatekeeper/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.H323GatekeeperListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*H323GatekeeperListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -97,8 +97,8 @@ func TestService_GetH323Gatekeeper(t *testing.T) {
 		Port:        &port,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/h323_gatekeeper/1/", mock.AnythingOfType("*config.H323Gatekeeper")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*H323Gatekeeper)
+	client.On("GetJSON", t.Context(), "configuration/v1/h323_gatekeeper/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.H323Gatekeeper")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*H323Gatekeeper)
 		*result = *expectedGatekeeper
 	})
 

--- a/config/http_proxy.go
+++ b/config/http_proxy.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListHTTPProxies(ctx context.Context, opts *ListOptions) (*HTTPProxyListResponse, error) {
 	endpoint := "configuration/v1/http_proxy/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result HTTPProxyListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetHTTPProxy(ctx context.Context, id int) (*HTTPProxy, error) 
 	endpoint := fmt.Sprintf("configuration/v1/http_proxy/%d/", id)
 
 	var result HTTPProxy
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/http_proxy_test.go
+++ b/config/http_proxy_test.go
@@ -35,8 +35,8 @@ func TestService_ListHTTPProxies(t *testing.T) {
 						{ID: 2, Name: "backup-proxy", Address: "backup.example.com", Port: &port2, Username: "user2", Password: "pass2", Protocol: "https"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/http_proxy/", mock.AnythingOfType("*config.HTTPProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*HTTPProxyListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/http_proxy/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.HTTPProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*HTTPProxyListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -57,8 +57,8 @@ func TestService_ListHTTPProxies(t *testing.T) {
 						{ID: 1, Name: "primary-proxy", Address: "proxy.example.com", Port: &port, Username: "user1", Password: "pass1", Protocol: "http"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/http_proxy/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.HTTPProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*HTTPProxyListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/http_proxy/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.HTTPProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*HTTPProxyListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -101,8 +101,8 @@ func TestService_GetHTTPProxy(t *testing.T) {
 		ResourceURI: "/api/admin/configuration/v1/http_proxy/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/http_proxy/1/", mock.AnythingOfType("*config.HTTPProxy")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*HTTPProxy)
+	client.On("GetJSON", t.Context(), "configuration/v1/http_proxy/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.HTTPProxy")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*HTTPProxy)
 		*result = *expectedProxy
 	})
 

--- a/config/identity_provider.go
+++ b/config/identity_provider.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListIdentityProviders(ctx context.Context, opts *ListOptions) (*IdentityProviderListResponse, error) {
 	endpoint := "configuration/v1/identity_provider/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result IdentityProviderListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetIdentityProvider(ctx context.Context, id int) (*IdentityPro
 	endpoint := fmt.Sprintf("configuration/v1/identity_provider/%d/", id)
 
 	var result IdentityProvider
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/identity_provider_attribute.go
+++ b/config/identity_provider_attribute.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListIdentityProviderAttributes(ctx context.Context, opts *ListOptions) (*IdentityProviderAttributeListResponse, error) {
 	endpoint := "configuration/v1/identity_provider_attribute/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result IdentityProviderAttributeListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetIdentityProviderAttribute(ctx context.Context, id int) (*Id
 	endpoint := fmt.Sprintf("configuration/v1/identity_provider_attribute/%d/", id)
 
 	var result IdentityProviderAttribute
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/identity_provider_attribute_test.go
+++ b/config/identity_provider_attribute_test.go
@@ -33,8 +33,8 @@ func TestService_ListIdentityProviderAttributes(t *testing.T) {
 						{ID: 2, Name: "email", Description: "User email address attribute"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/identity_provider_attribute/", mock.AnythingOfType("*config.IdentityProviderAttributeListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*IdentityProviderAttributeListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/identity_provider_attribute/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.IdentityProviderAttributeListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*IdentityProviderAttributeListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListIdentityProviderAttributes(t *testing.T) {
 						{ID: 2, Name: "email", Description: "User email address attribute"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/identity_provider_attribute/?limit=5&name__icontains=email", mock.AnythingOfType("*config.IdentityProviderAttributeListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*IdentityProviderAttributeListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/identity_provider_attribute/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.IdentityProviderAttributeListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*IdentityProviderAttributeListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -93,8 +93,8 @@ func TestService_GetIdentityProviderAttribute(t *testing.T) {
 		ResourceURI: "/api/admin/configuration/v1/identity_provider_attribute/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/identity_provider_attribute/1/", mock.AnythingOfType("*config.IdentityProviderAttribute")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*IdentityProviderAttribute)
+	client.On("GetJSON", t.Context(), "configuration/v1/identity_provider_attribute/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.IdentityProviderAttribute")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*IdentityProviderAttribute)
 		*result = *expectedAttribute
 	})
 

--- a/config/identity_provider_group.go
+++ b/config/identity_provider_group.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListIdentityProviderGroups(ctx context.Context, opts *ListOptions) (*IdentityProviderGroupListResponse, error) {
 	endpoint := "configuration/v1/identity_provider_group/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result IdentityProviderGroupListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetIdentityProviderGroup(ctx context.Context, id int) (*Identi
 	endpoint := fmt.Sprintf("configuration/v1/identity_provider_group/%d/", id)
 
 	var result IdentityProviderGroup
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/identity_provider_group_test.go
+++ b/config/identity_provider_group_test.go
@@ -48,8 +48,8 @@ func TestService_ListIdentityProviderGroups(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/identity_provider_group/", mock.AnythingOfType("*config.IdentityProviderGroupListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*IdentityProviderGroupListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/identity_provider_group/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.IdentityProviderGroupListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*IdentityProviderGroupListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -77,8 +77,8 @@ func TestService_ListIdentityProviderGroups(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/identity_provider_group/?limit=5&name__icontains=admin", mock.AnythingOfType("*config.IdentityProviderGroupListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*IdentityProviderGroupListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/identity_provider_group/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.IdentityProviderGroupListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*IdentityProviderGroupListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -120,8 +120,8 @@ func TestService_GetIdentityProviderGroup(t *testing.T) {
 		ResourceURI: "/api/admin/configuration/v1/identity_provider_group/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/identity_provider_group/1/", mock.AnythingOfType("*config.IdentityProviderGroup")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*IdentityProviderGroup)
+	client.On("GetJSON", t.Context(), "configuration/v1/identity_provider_group/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.IdentityProviderGroup")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*IdentityProviderGroup)
 		*result = *expectedGroup
 	})
 

--- a/config/identity_provider_test.go
+++ b/config/identity_provider_test.go
@@ -60,8 +60,8 @@ func TestService_ListIdentityProviders(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/identity_provider/", mock.AnythingOfType("*config.IdentityProviderListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*IdentityProviderListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/identity_provider/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.IdentityProviderListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*IdentityProviderListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -94,8 +94,8 @@ func TestService_ListIdentityProviders(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/identity_provider/?limit=5&name__icontains=saml", mock.AnythingOfType("*config.IdentityProviderListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*IdentityProviderListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/identity_provider/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.IdentityProviderListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*IdentityProviderListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -150,8 +150,8 @@ func TestService_GetIdentityProvider(t *testing.T) {
 		ResourceURI:                         "/api/admin/configuration/v1/identity_provider/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/identity_provider/1/", mock.AnythingOfType("*config.IdentityProvider")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*IdentityProvider)
+	client.On("GetJSON", t.Context(), "configuration/v1/identity_provider/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.IdentityProvider")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*IdentityProvider)
 		*result = *expectedProvider
 	})
 

--- a/config/ivr_theme.go
+++ b/config/ivr_theme.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListIVRThemes(ctx context.Context, opts *ListOptions) (*IVRThemeListResponse, error) {
 	endpoint := "configuration/v1/ivr_theme/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result IVRThemeListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetIVRTheme(ctx context.Context, id int) (*IVRTheme, error) {
 	endpoint := fmt.Sprintf("configuration/v1/ivr_theme/%d/", id)
 
 	var result IVRTheme
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/ivr_theme_test.go
+++ b/config/ivr_theme_test.go
@@ -57,8 +57,8 @@ func TestService_ListIVRThemes(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ivr_theme/", mock.AnythingOfType("*config.IVRThemeListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*IVRThemeListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ivr_theme/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.IVRThemeListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*IVRThemeListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -91,8 +91,8 @@ func TestService_ListIVRThemes(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ivr_theme/?limit=5&name__icontains=default", mock.AnythingOfType("*config.IVRThemeListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*IVRThemeListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ivr_theme/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.IVRThemeListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*IVRThemeListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -138,8 +138,8 @@ func TestService_GetIVRTheme(t *testing.T) {
 		ResourceURI:    "/api/admin/configuration/v1/ivr_theme/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/ivr_theme/1/", mock.AnythingOfType("*config.IVRTheme")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*IVRTheme)
+	client.On("GetJSON", t.Context(), "configuration/v1/ivr_theme/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.IVRTheme")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*IVRTheme)
 		*result = *expectedTheme
 	})
 

--- a/config/ldap_role.go
+++ b/config/ldap_role.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListLdapRoles(ctx context.Context, opts *ListOptions) (*LdapRoleListResponse, error) {
 	endpoint := "configuration/v1/ldap_role/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result LdapRoleListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetLdapRole(ctx context.Context, id int) (*LdapRole, error) {
 	endpoint := fmt.Sprintf("configuration/v1/ldap_role/%d/", id)
 
 	var result LdapRole
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/ldap_role_test.go
+++ b/config/ldap_role_test.go
@@ -48,8 +48,8 @@ func TestService_ListLdapRoles(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ldap_role/", mock.AnythingOfType("*config.LdapRoleListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*LdapRoleListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ldap_role/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LdapRoleListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*LdapRoleListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -77,8 +77,8 @@ func TestService_ListLdapRoles(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ldap_role/?limit=5&name__icontains=admin", mock.AnythingOfType("*config.LdapRoleListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*LdapRoleListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ldap_role/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LdapRoleListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*LdapRoleListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -120,8 +120,8 @@ func TestService_GetLdapRole(t *testing.T) {
 		ResourceURI: "/api/admin/configuration/v1/ldap_role/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/ldap_role/1/", mock.AnythingOfType("*config.LdapRole")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*LdapRole)
+	client.On("GetJSON", t.Context(), "configuration/v1/ldap_role/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LdapRole")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*LdapRole)
 		*result = *expectedRole
 	})
 

--- a/config/ldap_sync_field.go
+++ b/config/ldap_sync_field.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListLdapSyncFields(ctx context.Context, opts *ListOptions) (*LdapSyncFieldListResponse, error) {
 	endpoint := "configuration/v1/ldap_sync_field/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result LdapSyncFieldListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetLdapSyncField(ctx context.Context, id int) (*LdapSyncField,
 	endpoint := fmt.Sprintf("configuration/v1/ldap_sync_field/%d/", id)
 
 	var result LdapSyncField
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/ldap_sync_field_test.go
+++ b/config/ldap_sync_field_test.go
@@ -45,8 +45,8 @@ func TestService_ListLdapSyncFields(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ldap_sync_field/", mock.AnythingOfType("*config.LdapSyncFieldListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*LdapSyncFieldListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ldap_sync_field/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LdapSyncFieldListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*LdapSyncFieldListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -72,8 +72,8 @@ func TestService_ListLdapSyncFields(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ldap_sync_field/?limit=5&name__icontains=email", mock.AnythingOfType("*config.LdapSyncFieldListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*LdapSyncFieldListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ldap_sync_field/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LdapSyncFieldListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*LdapSyncFieldListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -113,8 +113,8 @@ func TestService_GetLdapSyncField(t *testing.T) {
 		ResourceURI:          "/api/admin/configuration/v1/ldap_sync_field/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/ldap_sync_field/1/", mock.AnythingOfType("*config.LdapSyncField")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*LdapSyncField)
+	client.On("GetJSON", t.Context(), "configuration/v1/ldap_sync_field/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LdapSyncField")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*LdapSyncField)
 		*result = *expectedField
 	})
 

--- a/config/ldap_sync_source.go
+++ b/config/ldap_sync_source.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListLdapSyncSources(ctx context.Context, opts *ListOptions) (*LdapSyncSourceListResponse, error) {
 	endpoint := "configuration/v1/ldap_sync_source/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result LdapSyncSourceListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetLdapSyncSource(ctx context.Context, id int) (*LdapSyncSourc
 	endpoint := fmt.Sprintf("configuration/v1/ldap_sync_source/%d/", id)
 
 	var result LdapSyncSource
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/ldap_sync_source_test.go
+++ b/config/ldap_sync_source_test.go
@@ -33,8 +33,8 @@ func TestService_ListLdapSyncSources(t *testing.T) {
 						{ID: 2, Name: "secondary-ldap", Description: "Secondary LDAP sync source", LdapServer: "ldap2.example.com", LdapBaseDN: "dc=example,dc=com", LdapBindUsername: "cn=admin,dc=example,dc=com", LdapUseGlobalCatalog: true, LdapPermitNoTLS: true},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ldap_sync_source/", mock.AnythingOfType("*config.LdapSyncSourceListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*LdapSyncSourceListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ldap_sync_source/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LdapSyncSourceListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*LdapSyncSourceListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListLdapSyncSources(t *testing.T) {
 						{ID: 1, Name: "primary-ldap", Description: "Primary LDAP sync source", LdapServer: "ldap.example.com", LdapBaseDN: "dc=example,dc=com", LdapBindUsername: "cn=admin,dc=example,dc=com", LdapUseGlobalCatalog: false, LdapPermitNoTLS: false},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ldap_sync_source/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.LdapSyncSourceListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*LdapSyncSourceListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ldap_sync_source/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LdapSyncSourceListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*LdapSyncSourceListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -98,8 +98,8 @@ func TestService_GetLdapSyncSource(t *testing.T) {
 		LdapPermitNoTLS:      false,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/ldap_sync_source/1/", mock.AnythingOfType("*config.LdapSyncSource")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*LdapSyncSource)
+	client.On("GetJSON", t.Context(), "configuration/v1/ldap_sync_source/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LdapSyncSource")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*LdapSyncSource)
 		*result = *expectedLdapSyncSource
 	})
 

--- a/config/licence.go
+++ b/config/licence.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListLicences(ctx context.Context, opts *ListOptions) (*LicenceListResponse, error) {
 	endpoint := "configuration/v1/licence/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result LicenceListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetLicence(ctx context.Context, fulfillmentID string) (*Licenc
 	endpoint := fmt.Sprintf("configuration/v1/licence/%s/", fulfillmentID)
 
 	var result Licence
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/licence_request.go
+++ b/config/licence_request.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListLicenceRequests(ctx context.Context, opts *ListOptions) (*LicenceRequestListResponse, error) {
 	endpoint := "configuration/v1/licence_request/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result LicenceRequestListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetLicenceRequest(ctx context.Context, sequenceNumber string) 
 	endpoint := fmt.Sprintf("configuration/v1/licence_request/%s/", sequenceNumber)
 
 	var result LicenceRequest
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/licence_request_test.go
+++ b/config/licence_request_test.go
@@ -34,8 +34,8 @@ func TestService_ListLicenceRequests(t *testing.T) {
 						{SequenceNumber: "REQ-002", Reference: "Upgrade License Request", Actions: "UPGRADE", GenerationTime: "2023-01-02T00:00:00Z", Status: "COMPLETED", ResponseXML: nil},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/licence_request/", mock.AnythingOfType("*config.LicenceRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*LicenceRequestListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/licence_request/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LicenceRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*LicenceRequestListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -56,8 +56,8 @@ func TestService_ListLicenceRequests(t *testing.T) {
 						{SequenceNumber: "REQ-001", Reference: "Annual License Request", Actions: "ISSUE", GenerationTime: "2023-01-01T00:00:00Z", Status: "PENDING", ResponseXML: &responseXML},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/licence_request/?limit=5&name__icontains=Annual", mock.AnythingOfType("*config.LicenceRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*LicenceRequestListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/licence_request/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LicenceRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*LicenceRequestListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -98,8 +98,8 @@ func TestService_GetLicenceRequest(t *testing.T) {
 		ResponseXML:    &responseXML,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/licence_request/REQ-123/", mock.AnythingOfType("*config.LicenceRequest")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*LicenceRequest)
+	client.On("GetJSON", t.Context(), "configuration/v1/licence_request/REQ-123/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LicenceRequest")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*LicenceRequest)
 		*result = *expectedLicenceRequest
 	})
 

--- a/config/licence_test.go
+++ b/config/licence_test.go
@@ -33,8 +33,8 @@ func TestService_ListLicences(t *testing.T) {
 						{FulfillmentID: "67890", ProductID: "pexip-vmr", Status: "active", Concurrent: 50, Activatable: 10},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/licence/", mock.AnythingOfType("*config.LicenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*LicenceListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/licence/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LicenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*LicenceListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListLicences(t *testing.T) {
 						{FulfillmentID: "12345", ProductID: "pexip-infinity", Status: "active", Concurrent: 100, Activatable: 25},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/licence/?limit=5&name__icontains=Infinity", mock.AnythingOfType("*config.LicenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*LicenceListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/licence/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LicenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*LicenceListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -96,8 +96,8 @@ func TestService_GetLicence(t *testing.T) {
 		ResourceURI:    "/api/admin/configuration/v1/licence/test-12345/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/licence/test-12345/", mock.AnythingOfType("*config.Licence")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*Licence)
+	client.On("GetJSON", t.Context(), "configuration/v1/licence/test-12345/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.Licence")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*Licence)
 		*result = *expectedLicence
 	})
 

--- a/config/location.go
+++ b/config/location.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListLocations(ctx context.Context, opts *ListOptions) (*LocationListResponse, error) {
 	endpoint := "configuration/v1/location/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result LocationListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetLocation(ctx context.Context, id int) (*Location, error) {
 	endpoint := fmt.Sprintf("configuration/v1/location/%d/", id)
 
 	var result Location
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/location_test.go
+++ b/config/location_test.go
@@ -26,8 +26,8 @@ func TestService_ListLocations(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/location/", mock.AnythingOfType("*config.LocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*LocationListResponse)
+	client.On("GetJSON", t.Context(), "configuration/v1/location/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*LocationListResponse)
 		*result = *expectedResponse
 	})
 
@@ -46,8 +46,8 @@ func TestService_GetLocation(t *testing.T) {
 		Name: "Test Location",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/location/1/", mock.AnythingOfType("*config.Location")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*Location)
+	client.On("GetJSON", t.Context(), "configuration/v1/location/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.Location")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*Location)
 		*result = *expectedLocation
 	})
 
@@ -136,8 +136,8 @@ func TestService_ListLocations_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/location/?limit=10&name__icontains=test&offset=5", mock.AnythingOfType("*config.LocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*LocationListResponse)
+	client.On("GetJSON", t.Context(), "configuration/v1/location/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*LocationListResponse)
 		*result = *expectedResponse
 	})
 

--- a/config/log_level.go
+++ b/config/log_level.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListLogLevels(ctx context.Context, opts *ListOptions) (*LogLevelListResponse, error) {
 	endpoint := "configuration/v1/log_level/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result LogLevelListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetLogLevel(ctx context.Context, id int) (*LogLevel, error) {
 	endpoint := fmt.Sprintf("configuration/v1/log_level/%d/", id)
 
 	var result LogLevel
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/log_level_test.go
+++ b/config/log_level_test.go
@@ -33,8 +33,8 @@ func TestService_ListLogLevels(t *testing.T) {
 						{ID: 2, Name: "conference_manager", Level: "DEBUG"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/log_level/", mock.AnythingOfType("*config.LogLevelListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*LogLevelListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/log_level/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LogLevelListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*LogLevelListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListLogLevels(t *testing.T) {
 						{ID: 1, Name: "media_processing", Level: "INFO"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/log_level/?limit=5&name__icontains=media", mock.AnythingOfType("*config.LogLevelListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*LogLevelListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/log_level/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LogLevelListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*LogLevelListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -92,8 +92,8 @@ func TestService_GetLogLevel(t *testing.T) {
 		Level: "WARN",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/log_level/1/", mock.AnythingOfType("*config.LogLevel")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*LogLevel)
+	client.On("GetJSON", t.Context(), "configuration/v1/log_level/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.LogLevel")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*LogLevel)
 		*result = *expectedLogLevel
 	})
 

--- a/config/management_vm.go
+++ b/config/management_vm.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListManagementVMs(ctx context.Context, opts *ListOptions) (*ManagementVMListResponse, error) {
 	endpoint := "configuration/v1/management_vm/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result ManagementVMListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetManagementVM(ctx context.Context, id int) (*ManagementVM, e
 	endpoint := fmt.Sprintf("configuration/v1/management_vm/%d/", id)
 
 	var result ManagementVM
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/management_vm_test.go
+++ b/config/management_vm_test.go
@@ -35,8 +35,8 @@ func TestService_ListManagementVMs(t *testing.T) {
 						{ID: 2, Name: "mgmt-vm-02", Description: "Secondary management VM", Address: "192.168.1.11", Netmask: "255.255.255.0", Gateway: "192.168.1.1", Hostname: "mgmt02", Domain: "example.com", MTU: 1500, EnableSSH: "disabled", SNMPMode: "disabled", Primary: false, Initializing: false},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/management_vm/", mock.AnythingOfType("*config.ManagementVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ManagementVMListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/management_vm/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ManagementVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ManagementVMListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -58,8 +58,8 @@ func TestService_ListManagementVMs(t *testing.T) {
 						{ID: 1, Name: "mgmt-vm-01", Description: "Primary management VM", Address: "192.168.1.10", Netmask: "255.255.255.0", Gateway: "192.168.1.1", Hostname: "mgmt01", Domain: "example.com", MTU: 1500, IPV6Address: &ipv6Address, StaticNATAddress: &natAddress, EnableSSH: "enabled", SNMPMode: "v2c", Primary: true, Initializing: false},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/management_vm/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.ManagementVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ManagementVMListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/management_vm/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ManagementVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ManagementVMListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -132,8 +132,8 @@ func TestService_GetManagementVM(t *testing.T) {
 		Initializing:               false,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/management_vm/1/", mock.AnythingOfType("*config.ManagementVM")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ManagementVM)
+	client.On("GetJSON", t.Context(), "configuration/v1/management_vm/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ManagementVM")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ManagementVM)
 		*result = *expectedManagementVM
 	})
 

--- a/config/media_library_entry.go
+++ b/config/media_library_entry.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListMediaLibraryEntries(ctx context.Context, opts *ListOptions) (*MediaLibraryEntryListResponse, error) {
 	endpoint := "configuration/v1/media_library_entry/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result MediaLibraryEntryListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetMediaLibraryEntry(ctx context.Context, id int) (*MediaLibra
 	endpoint := fmt.Sprintf("configuration/v1/media_library_entry/%d/", id)
 
 	var result MediaLibraryEntry
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/media_library_entry_test.go
+++ b/config/media_library_entry_test.go
@@ -33,8 +33,8 @@ func TestService_ListMediaLibraryEntries(t *testing.T) {
 						{ID: 2, Name: "hold-music", Description: "Music on hold", UUID: "123e4567-e89b-12d3-a456-426614174001", FileName: "hold.mp3", MediaType: "audio", MediaFormat: "audio/mpeg", MediaSize: 512000, MediaFile: "/media/hold.mp3"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/media_library_entry/", mock.AnythingOfType("*config.MediaLibraryEntryListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MediaLibraryEntryListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/media_library_entry/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MediaLibraryEntryListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MediaLibraryEntryListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListMediaLibraryEntries(t *testing.T) {
 						{ID: 1, Name: "welcome-video", Description: "Welcome video for conferences", UUID: "123e4567-e89b-12d3-a456-426614174000", FileName: "welcome.mp4", MediaType: "video", MediaFormat: "video/mp4", MediaSize: 1048576, MediaFile: "/media/welcome.mp4"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/media_library_entry/?limit=5&name__icontains=welcome", mock.AnythingOfType("*config.MediaLibraryEntryListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MediaLibraryEntryListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/media_library_entry/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MediaLibraryEntryListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MediaLibraryEntryListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -98,8 +98,8 @@ func TestService_GetMediaLibraryEntry(t *testing.T) {
 		MediaFile:   "/media/test.mp4",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/media_library_entry/1/", mock.AnythingOfType("*config.MediaLibraryEntry")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MediaLibraryEntry)
+	client.On("GetJSON", t.Context(), "configuration/v1/media_library_entry/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MediaLibraryEntry")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MediaLibraryEntry)
 		*result = *expectedMediaLibraryEntry
 	})
 

--- a/config/media_library_playlist.go
+++ b/config/media_library_playlist.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListMediaLibraryPlaylists(ctx context.Context, opts *ListOptions) (*MediaLibraryPlaylistListResponse, error) {
 	endpoint := "configuration/v1/media_library_playlist/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result MediaLibraryPlaylistListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetMediaLibraryPlaylist(ctx context.Context, id int) (*MediaLi
 	endpoint := fmt.Sprintf("configuration/v1/media_library_playlist/%d/", id)
 
 	var result MediaLibraryPlaylist
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/media_library_playlist_entry.go
+++ b/config/media_library_playlist_entry.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListMediaLibraryPlaylistEntries(ctx context.Context, opts *ListOptions) (*MediaLibraryPlaylistEntryListResponse, error) {
 	endpoint := "configuration/v1/media_library_playlist_entry/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result MediaLibraryPlaylistEntryListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetMediaLibraryPlaylistEntry(ctx context.Context, id int) (*Me
 	endpoint := fmt.Sprintf("configuration/v1/media_library_playlist_entry/%d/", id)
 
 	var result MediaLibraryPlaylistEntry
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/media_library_playlist_entry_test.go
+++ b/config/media_library_playlist_entry_test.go
@@ -37,8 +37,8 @@ func TestService_ListMediaLibraryPlaylistEntries(t *testing.T) {
 						{ID: 3, EntryType: "playlist", Playlist: &playlist1, Position: 3, Playcount: 2},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/media_library_playlist_entry/", mock.AnythingOfType("*config.MediaLibraryPlaylistEntryListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MediaLibraryPlaylistEntryListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/media_library_playlist_entry/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MediaLibraryPlaylistEntryListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MediaLibraryPlaylistEntryListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -61,8 +61,8 @@ func TestService_ListMediaLibraryPlaylistEntries(t *testing.T) {
 						{ID: 2, EntryType: "media", Media: &media2, Position: 2, Playcount: 5},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/media_library_playlist_entry/?limit=5&name__icontains=media", mock.AnythingOfType("*config.MediaLibraryPlaylistEntryListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MediaLibraryPlaylistEntryListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/media_library_playlist_entry/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MediaLibraryPlaylistEntryListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MediaLibraryPlaylistEntryListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -102,8 +102,8 @@ func TestService_GetMediaLibraryPlaylistEntry(t *testing.T) {
 		Playcount: 10,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/media_library_playlist_entry/1/", mock.AnythingOfType("*config.MediaLibraryPlaylistEntry")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MediaLibraryPlaylistEntry)
+	client.On("GetJSON", t.Context(), "configuration/v1/media_library_playlist_entry/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MediaLibraryPlaylistEntry")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MediaLibraryPlaylistEntry)
 		*result = *expectedMediaLibraryPlaylistEntry
 	})
 

--- a/config/media_library_playlist_test.go
+++ b/config/media_library_playlist_test.go
@@ -33,8 +33,8 @@ func TestService_ListMediaLibraryPlaylists(t *testing.T) {
 						{ID: 2, Name: "hold-music-playlist", Description: "Music on hold collection", Loop: true, Shuffle: true, PlaylistEntries: []string{"/api/admin/configuration/v1/media_library_playlist_entry/3/", "/api/admin/configuration/v1/media_library_playlist_entry/4/"}},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/media_library_playlist/", mock.AnythingOfType("*config.MediaLibraryPlaylistListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MediaLibraryPlaylistListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/media_library_playlist/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MediaLibraryPlaylistListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MediaLibraryPlaylistListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListMediaLibraryPlaylists(t *testing.T) {
 						{ID: 1, Name: "welcome-playlist", Description: "Welcome and onboarding videos", Loop: true, Shuffle: false, PlaylistEntries: []string{"/api/admin/configuration/v1/media_library_playlist_entry/1/", "/api/admin/configuration/v1/media_library_playlist_entry/2/"}},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/media_library_playlist/?limit=5&name__icontains=welcome", mock.AnythingOfType("*config.MediaLibraryPlaylistListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MediaLibraryPlaylistListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/media_library_playlist/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MediaLibraryPlaylistListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MediaLibraryPlaylistListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -99,8 +99,8 @@ func TestService_GetMediaLibraryPlaylist(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/media_library_playlist/1/", mock.AnythingOfType("*config.MediaLibraryPlaylist")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MediaLibraryPlaylist)
+	client.On("GetJSON", t.Context(), "configuration/v1/media_library_playlist/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MediaLibraryPlaylist")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MediaLibraryPlaylist)
 		*result = *expectedMediaLibraryPlaylist
 	})
 

--- a/config/media_processing_server.go
+++ b/config/media_processing_server.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListMediaProcessingServers(ctx context.Context, opts *ListOptions) (*MediaProcessingServerListResponse, error) {
 	endpoint := "configuration/v1/media_processing_server/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result MediaProcessingServerListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetMediaProcessingServer(ctx context.Context, id int) (*MediaP
 	endpoint := fmt.Sprintf("configuration/v1/media_processing_server/%d/", id)
 
 	var result MediaProcessingServer
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/media_processing_server_test.go
+++ b/config/media_processing_server_test.go
@@ -35,8 +35,8 @@ func TestService_ListMediaProcessingServers(t *testing.T) {
 						{ID: 2, FQDN: "media2.example.com", AppID: &appID2, PublicJWTKey: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...\n-----END PUBLIC KEY-----"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/media_processing_server/", mock.AnythingOfType("*config.MediaProcessingServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MediaProcessingServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/media_processing_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MediaProcessingServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MediaProcessingServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -57,8 +57,8 @@ func TestService_ListMediaProcessingServers(t *testing.T) {
 						{ID: 1, FQDN: "media1.example.com", AppID: &appID, PublicJWTKey: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...\n-----END PUBLIC KEY-----"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/media_processing_server/?limit=5&name__icontains=media1", mock.AnythingOfType("*config.MediaProcessingServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MediaProcessingServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/media_processing_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MediaProcessingServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MediaProcessingServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -97,8 +97,8 @@ func TestService_GetMediaProcessingServer(t *testing.T) {
 		PublicJWTKey: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtest...\n-----END PUBLIC KEY-----",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/media_processing_server/1/", mock.AnythingOfType("*config.MediaProcessingServer")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MediaProcessingServer)
+	client.On("GetJSON", t.Context(), "configuration/v1/media_processing_server/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MediaProcessingServer")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MediaProcessingServer)
 		*result = *expectedMediaProcessingServer
 	})
 

--- a/config/mjx_endpoint.go
+++ b/config/mjx_endpoint.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListMjxEndpoints(ctx context.Context, opts *ListOptions) (*MjxEndpointListResponse, error) {
 	endpoint := "configuration/v1/mjx_endpoint/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result MjxEndpointListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetMjxEndpoint(ctx context.Context, id int) (*MjxEndpoint, err
 	endpoint := fmt.Sprintf("configuration/v1/mjx_endpoint/%d/", id)
 
 	var result MjxEndpoint
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/mjx_endpoint_group.go
+++ b/config/mjx_endpoint_group.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListMjxEndpointGroups(ctx context.Context, opts *ListOptions) (*MjxEndpointGroupListResponse, error) {
 	endpoint := "configuration/v1/mjx_endpoint_group/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result MjxEndpointGroupListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetMjxEndpointGroup(ctx context.Context, id int) (*MjxEndpoint
 	endpoint := fmt.Sprintf("configuration/v1/mjx_endpoint_group/%d/", id)
 
 	var result MjxEndpointGroup
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/mjx_endpoint_group_test.go
+++ b/config/mjx_endpoint_group_test.go
@@ -38,8 +38,8 @@ func TestService_ListMjxEndpointGroups(t *testing.T) {
 						{ID: 2, Name: "floor-2-rooms", Description: "Conference rooms on floor 2", MjxIntegration: &integration2, SystemLocation: &location2, DisableProxy: true, Endpoints: []string{"/api/admin/configuration/v1/mjx_endpoint/3/", "/api/admin/configuration/v1/mjx_endpoint/4/"}},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_endpoint_group/", mock.AnythingOfType("*config.MjxEndpointGroupListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxEndpointGroupListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_endpoint_group/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxEndpointGroupListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxEndpointGroupListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -62,8 +62,8 @@ func TestService_ListMjxEndpointGroups(t *testing.T) {
 						{ID: 1, Name: "floor-1-rooms", Description: "Conference rooms on floor 1", MjxIntegration: &integration, SystemLocation: &location, DisableProxy: false, Endpoints: []string{"/api/admin/configuration/v1/mjx_endpoint/1/", "/api/admin/configuration/v1/mjx_endpoint/2/"}},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_endpoint_group/?limit=5&name__icontains=floor-1", mock.AnythingOfType("*config.MjxEndpointGroupListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxEndpointGroupListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_endpoint_group/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxEndpointGroupListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxEndpointGroupListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -111,8 +111,8 @@ func TestService_GetMjxEndpointGroup(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/mjx_endpoint_group/1/", mock.AnythingOfType("*config.MjxEndpointGroup")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MjxEndpointGroup)
+	client.On("GetJSON", t.Context(), "configuration/v1/mjx_endpoint_group/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxEndpointGroup")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MjxEndpointGroup)
 		*result = *expectedMjxEndpointGroup
 	})
 

--- a/config/mjx_endpoint_test.go
+++ b/config/mjx_endpoint_test.go
@@ -45,8 +45,8 @@ func TestService_ListMjxEndpoints(t *testing.T) {
 						{ID: 2, Name: "conf-room-02", Description: "Conference Room 02", EndpointType: "poly", RoomResourceEmail: "room02@example.com", MjxEndpointGroup: &group2, APIAddress: &apiAddress2, UseHTTPS: "no", VerifyCert: "no", PolyRaiseAlarmsForThisEndpoint: false},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_endpoint/", mock.AnythingOfType("*config.MjxEndpointListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxEndpointListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_endpoint/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxEndpointListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxEndpointListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -73,8 +73,8 @@ func TestService_ListMjxEndpoints(t *testing.T) {
 						{ID: 1, Name: "conf-room-01", Description: "Conference Room 01", EndpointType: "cisco", RoomResourceEmail: "room01@example.com", MjxEndpointGroup: &group, APIAddress: &apiAddress, APIPort: &apiPort, APIUsername: &apiUsername, APIPassword: &apiPassword, UseHTTPS: "yes", VerifyCert: "yes", PolyRaiseAlarmsForThisEndpoint: true, WebexDeviceID: &webexDeviceID},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_endpoint/?limit=5&name__icontains=conf-room-01", mock.AnythingOfType("*config.MjxEndpointListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxEndpointListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_endpoint/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxEndpointListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxEndpointListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -133,8 +133,8 @@ func TestService_GetMjxEndpoint(t *testing.T) {
 		WebexDeviceID:                  &webexDeviceID,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/mjx_endpoint/1/", mock.AnythingOfType("*config.MjxEndpoint")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MjxEndpoint)
+	client.On("GetJSON", t.Context(), "configuration/v1/mjx_endpoint/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxEndpoint")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MjxEndpoint)
 		*result = *expectedMjxEndpoint
 	})
 

--- a/config/mjx_exchange_autodiscover_url.go
+++ b/config/mjx_exchange_autodiscover_url.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListMjxExchangeAutodiscoverURLs(ctx context.Context, opts *ListOptions) (*MjxExchangeAutodiscoverURLListResponse, error) {
 	endpoint := "configuration/v1/mjx_exchange_autodiscover_url/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result MjxExchangeAutodiscoverURLListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetMjxExchangeAutodiscoverURL(ctx context.Context, id int) (*M
 	endpoint := fmt.Sprintf("configuration/v1/mjx_exchange_autodiscover_url/%d/", id)
 
 	var result MjxExchangeAutodiscoverURL
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/mjx_exchange_autodiscover_url_test.go
+++ b/config/mjx_exchange_autodiscover_url_test.go
@@ -34,8 +34,8 @@ func TestService_ListMjxExchangeAutodiscoverURLs(t *testing.T) {
 						{ID: 2, Name: "backup-autodiscover", Description: "Backup Exchange autodiscover URL", URL: "https://backup.example.com/autodiscover/autodiscover.xml", ExchangeDeployment: &exchangeDeployment},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_exchange_autodiscover_url/", mock.AnythingOfType("*config.MjxExchangeAutodiscoverURLListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxExchangeAutodiscoverURLListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_exchange_autodiscover_url/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxExchangeAutodiscoverURLListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxExchangeAutodiscoverURLListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -56,8 +56,8 @@ func TestService_ListMjxExchangeAutodiscoverURLs(t *testing.T) {
 						{ID: 1, Name: "primary-autodiscover", Description: "Primary Exchange autodiscover URL", URL: "https://autodiscover.example.com/autodiscover/autodiscover.xml", ExchangeDeployment: &exchangeDeployment},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_exchange_autodiscover_url/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.MjxExchangeAutodiscoverURLListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxExchangeAutodiscoverURLListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_exchange_autodiscover_url/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxExchangeAutodiscoverURLListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxExchangeAutodiscoverURLListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -98,8 +98,8 @@ func TestService_GetMjxExchangeAutodiscoverURL(t *testing.T) {
 		ExchangeDeployment: &exchangeDeployment,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/mjx_exchange_autodiscover_url/1/", mock.AnythingOfType("*config.MjxExchangeAutodiscoverURL")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MjxExchangeAutodiscoverURL)
+	client.On("GetJSON", t.Context(), "configuration/v1/mjx_exchange_autodiscover_url/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxExchangeAutodiscoverURL")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MjxExchangeAutodiscoverURL)
 		*result = *expectedURL
 	})
 

--- a/config/mjx_exchange_deployment.go
+++ b/config/mjx_exchange_deployment.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListMjxExchangeDeployments(ctx context.Context, opts *ListOptions) (*MjxExchangeDeploymentListResponse, error) {
 	endpoint := "configuration/v1/mjx_exchange_deployment/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result MjxExchangeDeploymentListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetMjxExchangeDeployment(ctx context.Context, id int) (*MjxExc
 	endpoint := fmt.Sprintf("configuration/v1/mjx_exchange_deployment/%d/", id)
 
 	var result MjxExchangeDeployment
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/mjx_exchange_deployment_test.go
+++ b/config/mjx_exchange_deployment_test.go
@@ -63,8 +63,8 @@ func TestService_ListMjxExchangeDeployments(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_exchange_deployment/", mock.AnythingOfType("*config.MjxExchangeDeploymentListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxExchangeDeploymentListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_exchange_deployment/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxExchangeDeploymentListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxExchangeDeploymentListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -92,8 +92,8 @@ func TestService_ListMjxExchangeDeployments(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_exchange_deployment/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.MjxExchangeDeploymentListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxExchangeDeploymentListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_exchange_deployment/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxExchangeDeploymentListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxExchangeDeploymentListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -154,8 +154,8 @@ func TestService_GetMjxExchangeDeployment(t *testing.T) {
 		MjxIntegrations:                []string{"/api/admin/configuration/v1/mjx_integration/1/"},
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/mjx_exchange_deployment/1/", mock.AnythingOfType("*config.MjxExchangeDeployment")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MjxExchangeDeployment)
+	client.On("GetJSON", t.Context(), "configuration/v1/mjx_exchange_deployment/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxExchangeDeployment")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MjxExchangeDeployment)
 		*result = *expectedDeployment
 	})
 

--- a/config/mjx_google_deployment.go
+++ b/config/mjx_google_deployment.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListMjxGoogleDeployments(ctx context.Context, opts *ListOptions) (*MjxGoogleDeploymentListResponse, error) {
 	endpoint := "configuration/v1/mjx_google_deployment/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result MjxGoogleDeploymentListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetMjxGoogleDeployment(ctx context.Context, id int) (*MjxGoogl
 	endpoint := fmt.Sprintf("configuration/v1/mjx_google_deployment/%d/", id)
 
 	var result MjxGoogleDeployment
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/mjx_google_deployment_test.go
+++ b/config/mjx_google_deployment_test.go
@@ -58,8 +58,8 @@ func TestService_ListMjxGoogleDeployments(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_google_deployment/", mock.AnythingOfType("*config.MjxGoogleDeploymentListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxGoogleDeploymentListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_google_deployment/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxGoogleDeploymentListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxGoogleDeploymentListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -86,8 +86,8 @@ func TestService_ListMjxGoogleDeployments(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_google_deployment/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.MjxGoogleDeploymentListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxGoogleDeploymentListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_google_deployment/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxGoogleDeploymentListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxGoogleDeploymentListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -138,8 +138,8 @@ func TestService_GetMjxGoogleDeployment(t *testing.T) {
 		MjxIntegrations:            []string{"/api/admin/configuration/v1/mjx_integration/1/", "/api/admin/configuration/v1/mjx_integration/2/"},
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/mjx_google_deployment/1/", mock.AnythingOfType("*config.MjxGoogleDeployment")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MjxGoogleDeployment)
+	client.On("GetJSON", t.Context(), "configuration/v1/mjx_google_deployment/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxGoogleDeployment")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MjxGoogleDeployment)
 		*result = *expectedDeployment
 	})
 

--- a/config/mjx_graph_deployment.go
+++ b/config/mjx_graph_deployment.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListMjxGraphDeployments(ctx context.Context, opts *ListOptions) (*MjxGraphDeploymentListResponse, error) {
 	endpoint := "configuration/v1/mjx_graph_deployment/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result MjxGraphDeploymentListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetMjxGraphDeployment(ctx context.Context, id int) (*MjxGraphD
 	endpoint := fmt.Sprintf("configuration/v1/mjx_graph_deployment/%d/", id)
 
 	var result MjxGraphDeployment
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/mjx_graph_deployment_test.go
+++ b/config/mjx_graph_deployment_test.go
@@ -53,8 +53,8 @@ func TestService_ListMjxGraphDeployments(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_graph_deployment/", mock.AnythingOfType("*config.MjxGraphDeploymentListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxGraphDeploymentListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_graph_deployment/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxGraphDeploymentListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxGraphDeploymentListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -83,8 +83,8 @@ func TestService_ListMjxGraphDeployments(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_graph_deployment/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.MjxGraphDeploymentListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxGraphDeploymentListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_graph_deployment/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxGraphDeploymentListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxGraphDeploymentListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -132,8 +132,8 @@ func TestService_GetMjxGraphDeployment(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/mjx_graph_deployment/1/", mock.AnythingOfType("*config.MjxGraphDeployment")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MjxGraphDeployment)
+	client.On("GetJSON", t.Context(), "configuration/v1/mjx_graph_deployment/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxGraphDeployment")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MjxGraphDeployment)
 		*result = *expectedDeployment
 	})
 

--- a/config/mjx_integration.go
+++ b/config/mjx_integration.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListMjxIntegrations(ctx context.Context, opts *ListOptions) (*MjxIntegrationListResponse, error) {
 	endpoint := "configuration/v1/mjx_integration/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result MjxIntegrationListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetMjxIntegration(ctx context.Context, id int) (*MjxIntegratio
 	endpoint := fmt.Sprintf("configuration/v1/mjx_integration/%d/", id)
 
 	var result MjxIntegration
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/mjx_integration_test.go
+++ b/config/mjx_integration_test.go
@@ -86,8 +86,8 @@ func TestService_ListMjxIntegrations(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_integration/", mock.AnythingOfType("*config.MjxIntegrationListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxIntegrationListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_integration/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxIntegrationListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxIntegrationListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -116,8 +116,8 @@ func TestService_ListMjxIntegrations(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_integration/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.MjxIntegrationListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxIntegrationListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_integration/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxIntegrationListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxIntegrationListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -187,8 +187,8 @@ func TestService_GetMjxIntegration(t *testing.T) {
 		EndpointGroups:              []string{"/api/admin/configuration/v1/mjx_endpoint_group/1/", "/api/admin/configuration/v1/mjx_endpoint_group/2/"},
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/mjx_integration/1/", mock.AnythingOfType("*config.MjxIntegration")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MjxIntegration)
+	client.On("GetJSON", t.Context(), "configuration/v1/mjx_integration/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxIntegration")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MjxIntegration)
 		*result = *expectedIntegration
 	})
 

--- a/config/mjx_meeting_processing_rule.go
+++ b/config/mjx_meeting_processing_rule.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListMjxMeetingProcessingRules(ctx context.Context, opts *ListOptions) (*MjxMeetingProcessingRuleListResponse, error) {
 	endpoint := "configuration/v1/mjx_meeting_processing_rule/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result MjxMeetingProcessingRuleListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetMjxMeetingProcessingRule(ctx context.Context, id int) (*Mjx
 	endpoint := fmt.Sprintf("configuration/v1/mjx_meeting_processing_rule/%d/", id)
 
 	var result MjxMeetingProcessingRule
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/mjx_meeting_processing_rule_test.go
+++ b/config/mjx_meeting_processing_rule_test.go
@@ -64,8 +64,8 @@ func TestService_ListMjxMeetingProcessingRules(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_meeting_processing_rule/", mock.AnythingOfType("*config.MjxMeetingProcessingRuleListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxMeetingProcessingRuleListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_meeting_processing_rule/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxMeetingProcessingRuleListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxMeetingProcessingRuleListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -94,8 +94,8 @@ func TestService_ListMjxMeetingProcessingRules(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mjx_meeting_processing_rule/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.MjxMeetingProcessingRuleListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MjxMeetingProcessingRuleListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mjx_meeting_processing_rule/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxMeetingProcessingRuleListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MjxMeetingProcessingRuleListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -145,8 +145,8 @@ func TestService_GetMjxMeetingProcessingRule(t *testing.T) {
 		DefaultProcessingEnabled: true,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/mjx_meeting_processing_rule/1/", mock.AnythingOfType("*config.MjxMeetingProcessingRule")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MjxMeetingProcessingRule)
+	client.On("GetJSON", t.Context(), "configuration/v1/mjx_meeting_processing_rule/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MjxMeetingProcessingRule")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MjxMeetingProcessingRule)
 		*result = *expectedRule
 	})
 

--- a/config/ms_exchange_connector.go
+++ b/config/ms_exchange_connector.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListMsExchangeConnectors(ctx context.Context, opts *ListOptions) (*MsExchangeConnectorListResponse, error) {
 	endpoint := "configuration/v1/ms_exchange_connector/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result MsExchangeConnectorListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetMsExchangeConnector(ctx context.Context, id int) (*MsExchan
 	endpoint := fmt.Sprintf("configuration/v1/ms_exchange_connector/%d/", id)
 
 	var result MsExchangeConnector
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/ms_exchange_connector_test.go
+++ b/config/ms_exchange_connector_test.go
@@ -110,8 +110,8 @@ func TestService_ListMsExchangeConnectors(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ms_exchange_connector/", mock.AnythingOfType("*config.MsExchangeConnectorListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MsExchangeConnectorListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ms_exchange_connector/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MsExchangeConnectorListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MsExchangeConnectorListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -145,8 +145,8 @@ func TestService_ListMsExchangeConnectors(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ms_exchange_connector/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.MsExchangeConnectorListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MsExchangeConnectorListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ms_exchange_connector/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MsExchangeConnectorListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MsExchangeConnectorListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -301,8 +301,8 @@ func TestService_GetMsExchangeConnector(t *testing.T) {
 		PublicKey:                 "test-public-key",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/ms_exchange_connector/1/", mock.AnythingOfType("*config.MsExchangeConnector")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MsExchangeConnector)
+	client.On("GetJSON", t.Context(), "configuration/v1/ms_exchange_connector/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MsExchangeConnector")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MsExchangeConnector)
 		*result = *expectedConnector
 	})
 

--- a/config/mssip_proxy.go
+++ b/config/mssip_proxy.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListMSSIPProxies(ctx context.Context, opts *ListOptions) (*MSSIPProxyListResponse, error) {
 	endpoint := "configuration/v1/mssip_proxy/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result MSSIPProxyListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetMSSIPProxy(ctx context.Context, id int) (*MSSIPProxy, error
 	endpoint := fmt.Sprintf("configuration/v1/mssip_proxy/%d/", id)
 
 	var result MSSIPProxy
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/mssip_proxy_test.go
+++ b/config/mssip_proxy_test.go
@@ -49,8 +49,8 @@ func TestService_ListMSSIPProxies(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mssip_proxy/", mock.AnythingOfType("*config.MSSIPProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MSSIPProxyListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mssip_proxy/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MSSIPProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MSSIPProxyListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -78,8 +78,8 @@ func TestService_ListMSSIPProxies(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/mssip_proxy/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.MSSIPProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*MSSIPProxyListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/mssip_proxy/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MSSIPProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*MSSIPProxyListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -121,8 +121,8 @@ func TestService_GetMSSIPProxy(t *testing.T) {
 		Transport:   "tcp",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/mssip_proxy/1/", mock.AnythingOfType("*config.MSSIPProxy")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MSSIPProxy)
+	client.On("GetJSON", t.Context(), "configuration/v1/mssip_proxy/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.MSSIPProxy")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MSSIPProxy)
 		*result = *expectedProxy
 	})
 

--- a/config/ntp_server.go
+++ b/config/ntp_server.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListNTPServers(ctx context.Context, opts *ListOptions) (*NTPServerListResponse, error) {
 	endpoint := "configuration/v1/ntp_server/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result NTPServerListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetNTPServer(ctx context.Context, id int) (*NTPServer, error) 
 	endpoint := fmt.Sprintf("configuration/v1/ntp_server/%d/", id)
 
 	var result NTPServer
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/ntp_server_test.go
+++ b/config/ntp_server_test.go
@@ -33,8 +33,8 @@ func TestService_ListNTPServers(t *testing.T) {
 						{ID: 2, Address: "time.google.com", Description: "Google Time"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ntp_server/", mock.AnythingOfType("*config.NTPServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*NTPServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ntp_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.NTPServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*NTPServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -55,8 +55,8 @@ func TestService_ListNTPServers(t *testing.T) {
 						{ID: 2, Address: "time.google.com", Description: "Google Time"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ntp_server/?limit=3&name__icontains=google&offset=1", mock.AnythingOfType("*config.NTPServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*NTPServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ntp_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.NTPServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*NTPServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -96,8 +96,8 @@ func TestService_GetNTPServer(t *testing.T) {
 		KeyID:       &keyID,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/ntp_server/1/", mock.AnythingOfType("*config.NTPServer")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*NTPServer)
+	client.On("GetJSON", t.Context(), "configuration/v1/ntp_server/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.NTPServer")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*NTPServer)
 		*result = *expectedServer
 	})
 

--- a/config/oauth2_client.go
+++ b/config/oauth2_client.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListOAuth2Clients(ctx context.Context, opts *ListOptions) (*OAuth2ClientListResponse, error) {
 	endpoint := "configuration/v1/oauth2_client/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result OAuth2ClientListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetOAuth2Client(ctx context.Context, clientID string) (*OAuth2
 	endpoint := fmt.Sprintf("configuration/v1/oauth2_client/%s/", clientID)
 
 	var result OAuth2Client
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/oauth2_client_test.go
+++ b/config/oauth2_client_test.go
@@ -35,8 +35,8 @@ func TestService_ListOAuth2Clients(t *testing.T) {
 						{ClientID: "client-2", ClientName: "Secondary OAuth2 Client", Role: "user", PrivateKeyJWT: &privateKeyJWT2},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/oauth2_client/", mock.AnythingOfType("*config.OAuth2ClientListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*OAuth2ClientListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/oauth2_client/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.OAuth2ClientListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*OAuth2ClientListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -57,8 +57,8 @@ func TestService_ListOAuth2Clients(t *testing.T) {
 						{ClientID: "client-1", ClientName: "Primary OAuth2 Client", Role: "admin", PrivateKeyJWT: &privateKeyJWT},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/oauth2_client/?limit=5&name__icontains=Primary", mock.AnythingOfType("*config.OAuth2ClientListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*OAuth2ClientListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/oauth2_client/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.OAuth2ClientListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*OAuth2ClientListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -97,8 +97,8 @@ func TestService_GetOAuth2Client(t *testing.T) {
 		PrivateKeyJWT: &privateKeyJWT,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/oauth2_client/test-client-id/", mock.AnythingOfType("*config.OAuth2Client")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*OAuth2Client)
+	client.On("GetJSON", t.Context(), "configuration/v1/oauth2_client/test-client-id/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.OAuth2Client")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*OAuth2Client)
 		*result = *expectedOAuth2Client
 	})
 

--- a/config/permission.go
+++ b/config/permission.go
@@ -9,21 +9,21 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 )
 
 // ListPermissions retrieves a list of permissions (read-only)
 func (s *Service) ListPermissions(ctx context.Context, opts *ListOptions) (*PermissionListResponse, error) {
 	endpoint := "configuration/v1/permission/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result PermissionListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -32,6 +32,6 @@ func (s *Service) GetPermission(ctx context.Context, id int) (*Permission, error
 	endpoint := fmt.Sprintf("configuration/v1/permission/%d/", id)
 
 	var result Permission
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/config/permission_test.go
+++ b/config/permission_test.go
@@ -80,8 +80,8 @@ func TestService_ListPermissions(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/permission/", mock.AnythingOfType("*config.PermissionListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*PermissionListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/permission/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.PermissionListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*PermissionListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -120,8 +120,8 @@ func TestService_ListPermissions(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/permission/?limit=5&name__icontains=conference", mock.AnythingOfType("*config.PermissionListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*PermissionListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/permission/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.PermissionListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*PermissionListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -159,8 +159,8 @@ func TestService_GetPermission(t *testing.T) {
 		Codename: "add_conference",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/permission/1/", mock.AnythingOfType("*config.Permission")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*Permission)
+	client.On("GetJSON", t.Context(), "configuration/v1/permission/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.Permission")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*Permission)
 		*result = *expectedPermission
 	})
 

--- a/config/pexip_streaming_credential.go
+++ b/config/pexip_streaming_credential.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListPexipStreamingCredentials(ctx context.Context, opts *ListOptions) (*PexipStreamingCredentialListResponse, error) {
 	endpoint := "configuration/v1/pexip_streaming_credential/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result PexipStreamingCredentialListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetPexipStreamingCredential(ctx context.Context, id int) (*Pex
 	endpoint := fmt.Sprintf("configuration/v1/pexip_streaming_credential/%d/", id)
 
 	var result PexipStreamingCredential
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/pexip_streaming_credential_test.go
+++ b/config/pexip_streaming_credential_test.go
@@ -41,8 +41,8 @@ func TestService_ListPexipStreamingCredentials(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/pexip_streaming_credential/", mock.AnythingOfType("*config.PexipStreamingCredentialListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*PexipStreamingCredentialListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/pexip_streaming_credential/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.PexipStreamingCredentialListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*PexipStreamingCredentialListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -66,8 +66,8 @@ func TestService_ListPexipStreamingCredentials(t *testing.T) {
 						},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/pexip_streaming_credential/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.PexipStreamingCredentialListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*PexipStreamingCredentialListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/pexip_streaming_credential/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.PexipStreamingCredentialListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*PexipStreamingCredentialListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -105,8 +105,8 @@ func TestService_GetPexipStreamingCredential(t *testing.T) {
 		PublicKey: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxyz1lCKE8rMQS7MdJvzz\nGtx3Ip8K7OqN9ZKF2eODJzCq3ZOD4oBnVtJOv3V8XqOWLm8HRgfEKVkZtQz2pMJ3\nJ5dT4V6L9QxzB7wX8oGjWzF9QyX8LmN2VfZpJzOKvQyF6qRz3tJ9QyNkD8G7X2Lf\nL8QV9rOq3ZdFG7wX2qVzPyGjNkT4V9LrOz3QyF8V2Lm3J9ZFq7wXzGjNkL8Vr2Qy\nF9LmOz3V7wXGjN4T8V2Lm3QyF9ZrOzVf7wXGjNkT8V2LmQyF9ZOz3V7wGjN4TLmQ\nyVZrOz3F7wXGjNkT8V2LmQyFZOzV7wXGjN4TLmQyVZOzF7wGjNkTLmQyVZF7wGjN\nQIDAQAB\n-----END PUBLIC KEY-----",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/pexip_streaming_credential/1/", mock.AnythingOfType("*config.PexipStreamingCredential")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*PexipStreamingCredential)
+	client.On("GetJSON", t.Context(), "configuration/v1/pexip_streaming_credential/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.PexipStreamingCredential")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*PexipStreamingCredential)
 		*result = *expectedCredential
 	})
 

--- a/config/policy_server.go
+++ b/config/policy_server.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListPolicyServers(ctx context.Context, opts *ListOptions) (*PolicyServerListResponse, error) {
 	endpoint := "configuration/v1/policy_server/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result PolicyServerListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetPolicyServer(ctx context.Context, id int) (*PolicyServer, e
 	endpoint := fmt.Sprintf("configuration/v1/policy_server/%d/", id)
 
 	var result PolicyServer
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/policy_server_test.go
+++ b/config/policy_server_test.go
@@ -33,8 +33,8 @@ func TestService_ListPolicyServers(t *testing.T) {
 						{ID: 2, Name: "policy-server2", Description: "Secondary policy server", URL: "https://policy2.example.com", EnableDirectoryLookup: true, EnableAvatarLookup: true},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/policy_server/", mock.AnythingOfType("*config.PolicyServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*PolicyServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/policy_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.PolicyServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*PolicyServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListPolicyServers(t *testing.T) {
 						{ID: 1, Name: "policy-server1", Description: "Primary policy server", URL: "https://policy.example.com", EnableServiceLookup: true, EnableParticipantLookup: true},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/policy_server/?limit=5&name__icontains=policy-server1", mock.AnythingOfType("*config.PolicyServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*PolicyServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/policy_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.PolicyServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*PolicyServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -108,8 +108,8 @@ func TestService_GetPolicyServer(t *testing.T) {
 		PreferLocalAvatarConfiguration:      true,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/policy_server/1/", mock.AnythingOfType("*config.PolicyServer")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*PolicyServer)
+	client.On("GetJSON", t.Context(), "configuration/v1/policy_server/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.PolicyServer")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*PolicyServer)
 		*result = *expectedPolicyServer
 	})
 

--- a/config/recurring_conference.go
+++ b/config/recurring_conference.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListRecurringConferences(ctx context.Context, opts *ListOptions) (*RecurringConferenceListResponse, error) {
 	endpoint := "configuration/v1/recurring_conference/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result RecurringConferenceListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetRecurringConference(ctx context.Context, id int) (*Recurrin
 	endpoint := fmt.Sprintf("configuration/v1/recurring_conference/%d/", id)
 
 	var result RecurringConference
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/recurring_conference_test.go
+++ b/config/recurring_conference_test.go
@@ -35,8 +35,8 @@ func TestService_ListRecurringConferences(t *testing.T) {
 						{ID: 2, Conference: "monthly-review", CurrentIndex: 2, EWSItemID: "ews-id-2", IsDepleted: false, Subject: "Monthly Review", ScheduledAlias: &scheduledAlias2},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/recurring_conference/", mock.AnythingOfType("*config.RecurringConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*RecurringConferenceListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/recurring_conference/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.RecurringConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*RecurringConferenceListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -57,8 +57,8 @@ func TestService_ListRecurringConferences(t *testing.T) {
 						{ID: 1, Conference: "weekly-standup", CurrentIndex: 5, EWSItemID: "ews-id-1", IsDepleted: false, Subject: "Weekly Standup", ScheduledAlias: &scheduledAlias},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/recurring_conference/?limit=5&name__icontains=weekly", mock.AnythingOfType("*config.RecurringConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*RecurringConferenceListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/recurring_conference/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.RecurringConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*RecurringConferenceListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -100,8 +100,8 @@ func TestService_GetRecurringConference(t *testing.T) {
 		ScheduledAlias: &scheduledAlias,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/recurring_conference/1/", mock.AnythingOfType("*config.RecurringConference")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*RecurringConference)
+	client.On("GetJSON", t.Context(), "configuration/v1/recurring_conference/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.RecurringConference")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*RecurringConference)
 		*result = *expectedRecurringConference
 	})
 

--- a/config/registration.go
+++ b/config/registration.go
@@ -15,7 +15,7 @@ func (s *Service) GetRegistration(ctx context.Context) (*Registration, error) {
 	endpoint := "configuration/v1/registration/1/"
 
 	var result Registration
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/registration_test.go
+++ b/config/registration_test.go
@@ -32,8 +32,8 @@ func TestService_GetRegistration(t *testing.T) {
 		PushToken:                  "push-token-123",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/registration/1/", mock.AnythingOfType("*config.Registration")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*Registration)
+	client.On("GetJSON", t.Context(), "configuration/v1/registration/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.Registration")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*Registration)
 		*result = *expectedRegistration
 	})
 

--- a/config/role.go
+++ b/config/role.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListRoles(ctx context.Context, opts *ListOptions) (*RoleListResponse, error) {
 	endpoint := "configuration/v1/role/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result RoleListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetRole(ctx context.Context, id int) (*Role, error) {
 	endpoint := fmt.Sprintf("configuration/v1/role/%d/", id)
 
 	var result Role
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/role_mapping.go
+++ b/config/role_mapping.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListRoleMappings(ctx context.Context, opts *ListOptions) (*RoleMappingListResponse, error) {
 	endpoint := "configuration/v1/role_mapping/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result RoleMappingListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetRoleMapping(ctx context.Context, id int) (*RoleMapping, err
 	endpoint := fmt.Sprintf("configuration/v1/role_mapping/%d/", id)
 
 	var result RoleMapping
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/role_mapping_test.go
+++ b/config/role_mapping_test.go
@@ -33,8 +33,8 @@ func TestService_ListRoleMappings(t *testing.T) {
 						{ID: 2, Name: "user-mapping", Source: "ldap", Value: "CN=Users,OU=Groups,DC=example,DC=com", Roles: []string{"user"}},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/role_mapping/", mock.AnythingOfType("*config.RoleMappingListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*RoleMappingListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/role_mapping/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.RoleMappingListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*RoleMappingListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListRoleMappings(t *testing.T) {
 						{ID: 1, Name: "admin-mapping", Source: "ldap", Value: "CN=Administrators,OU=Groups,DC=example,DC=com", Roles: []string{"admin", "user"}},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/role_mapping/?limit=5&name__icontains=admin", mock.AnythingOfType("*config.RoleMappingListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*RoleMappingListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/role_mapping/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.RoleMappingListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*RoleMappingListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -94,8 +94,8 @@ func TestService_GetRoleMapping(t *testing.T) {
 		Roles:  []string{"admin", "user", "moderator"},
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/role_mapping/1/", mock.AnythingOfType("*config.RoleMapping")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*RoleMapping)
+	client.On("GetJSON", t.Context(), "configuration/v1/role_mapping/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.RoleMapping")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*RoleMapping)
 		*result = *expectedRoleMapping
 	})
 

--- a/config/role_test.go
+++ b/config/role_test.go
@@ -33,8 +33,8 @@ func TestService_ListRoles(t *testing.T) {
 						{ID: 2, Name: "user", Permissions: []string{"basic_access"}},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/role/", mock.AnythingOfType("*config.RoleListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*RoleListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/role/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.RoleListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*RoleListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListRoles(t *testing.T) {
 						{ID: 1, Name: "admin", Permissions: []string{"admin", "user_management"}},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/role/?limit=5&name__icontains=admin", mock.AnythingOfType("*config.RoleListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*RoleListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/role/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.RoleListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*RoleListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -93,8 +93,8 @@ func TestService_GetRole(t *testing.T) {
 		ResourceURI: "/api/admin/configuration/v1/role/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/role/1/", mock.AnythingOfType("*config.Role")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*Role)
+	client.On("GetJSON", t.Context(), "configuration/v1/role/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.Role")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*Role)
 		*result = *expectedRole
 	})
 

--- a/config/scheduled_alias.go
+++ b/config/scheduled_alias.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListScheduledAliases(ctx context.Context, opts *ListOptions) (*ScheduledAliasListResponse, error) {
 	endpoint := "configuration/v1/scheduled_alias/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result ScheduledAliasListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetScheduledAlias(ctx context.Context, id int) (*ScheduledAlia
 	endpoint := fmt.Sprintf("configuration/v1/scheduled_alias/%d/", id)
 
 	var result ScheduledAlias
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/scheduled_alias_test.go
+++ b/config/scheduled_alias_test.go
@@ -40,8 +40,8 @@ func TestService_ListScheduledAliases(t *testing.T) {
 						{ID: 2, Alias: "meeting.room2", AliasNumber: 1002, NumericAlias: "1002", UUID: "uuid-2", ExchangeConnector: "exchange2", IsUsed: false, EWSItemUID: &ewsItemUID2, ConferenceDeletionTime: &deletionTime},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/scheduled_alias/", mock.AnythingOfType("*config.ScheduledAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ScheduledAliasListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/scheduled_alias/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ScheduledAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ScheduledAliasListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -64,8 +64,8 @@ func TestService_ListScheduledAliases(t *testing.T) {
 						{ID: 1, Alias: "meeting.room1", AliasNumber: 1001, NumericAlias: "1001", UUID: "uuid-1", ExchangeConnector: "exchange1", IsUsed: true, EWSItemUID: &ewsItemUID, CreationTime: creationTime},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/scheduled_alias/?limit=5&name__icontains=room1", mock.AnythingOfType("*config.ScheduledAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ScheduledAliasListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/scheduled_alias/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ScheduledAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ScheduledAliasListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -113,8 +113,8 @@ func TestService_GetScheduledAlias(t *testing.T) {
 		ConferenceDeletionTime: &deletionTime,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/scheduled_alias/1/", mock.AnythingOfType("*config.ScheduledAlias")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ScheduledAlias)
+	client.On("GetJSON", t.Context(), "configuration/v1/scheduled_alias/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ScheduledAlias")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ScheduledAlias)
 		*result = *expectedScheduledAlias
 	})
 

--- a/config/scheduled_conference.go
+++ b/config/scheduled_conference.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListScheduledConferences(ctx context.Context, opts *ListOptions) (*ScheduledConferenceListResponse, error) {
 	endpoint := "configuration/v1/scheduled_conference/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result ScheduledConferenceListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetScheduledConference(ctx context.Context, id int) (*Schedule
 	endpoint := fmt.Sprintf("configuration/v1/scheduled_conference/%d/", id)
 
 	var result ScheduledConference
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/scheduled_conference_test.go
+++ b/config/scheduled_conference_test.go
@@ -43,8 +43,8 @@ func TestService_ListScheduledConferences(t *testing.T) {
 						{ID: 2, Conference: "/api/admin/configuration/v1/conference/2/", StartTime: startTime2, EndTime: endTime2, Subject: "Project Review", EWSItemID: "ews-id-2", EWSItemUID: "ews-uid-2", ScheduledAlias: &scheduledAlias2},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/scheduled_conference/", mock.AnythingOfType("*config.ScheduledConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ScheduledConferenceListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/scheduled_conference/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ScheduledConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ScheduledConferenceListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -69,8 +69,8 @@ func TestService_ListScheduledConferences(t *testing.T) {
 						{ID: 1, Conference: "/api/admin/configuration/v1/conference/1/", StartTime: startTime, EndTime: endTime, Subject: "Weekly Team Meeting", EWSItemID: "ews-id-1", EWSItemUID: "ews-uid-1", RecurringConference: &recurringConf, ScheduledAlias: &scheduledAlias},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/scheduled_conference/?limit=5&name__icontains=team", mock.AnythingOfType("*config.ScheduledConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ScheduledConferenceListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/scheduled_conference/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ScheduledConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ScheduledConferenceListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -118,8 +118,8 @@ func TestService_GetScheduledConference(t *testing.T) {
 		ScheduledAlias:      &scheduledAlias,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/scheduled_conference/1/", mock.AnythingOfType("*config.ScheduledConference")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ScheduledConference)
+	client.On("GetJSON", t.Context(), "configuration/v1/scheduled_conference/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ScheduledConference")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ScheduledConference)
 		*result = *expectedScheduledConference
 	})
 

--- a/config/scheduled_scaling.go
+++ b/config/scheduled_scaling.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListScheduledScalings(ctx context.Context, opts *ListOptions) (*ScheduledScalingListResponse, error) {
 	endpoint := "configuration/v1/scheduled_scaling/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result ScheduledScalingListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetScheduledScaling(ctx context.Context, id int) (*ScheduledSc
 	endpoint := fmt.Sprintf("configuration/v1/scheduled_scaling/%d/", id)
 
 	var result ScheduledScaling
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/scheduled_scaling_test.go
+++ b/config/scheduled_scaling_test.go
@@ -38,8 +38,8 @@ func TestService_ListScheduledScalings(t *testing.T) {
 						{ID: 2, PolicyName: "peak-hours", PolicyType: "daily", ResourceIdentifier: "media-nodes", Enabled: true, InstancesToAdd: 3, MinutesInAdvance: 15, LocalTimezone: "America/New_York", StartDate: "2023-10-02", TimeFrom: "08:00", TimeTo: "18:00", Mon: true, Tue: true, Wed: true, Thu: true, Fri: true, Sat: true, Sun: true, Updated: &updated2},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/scheduled_scaling/", mock.AnythingOfType("*config.ScheduledScalingListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ScheduledScalingListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/scheduled_scaling/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ScheduledScalingListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ScheduledScalingListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -61,8 +61,8 @@ func TestService_ListScheduledScalings(t *testing.T) {
 						{ID: 1, PolicyName: "weekend-scaling", PolicyType: "weekly", ResourceIdentifier: "conferencing-nodes", Enabled: true, InstancesToAdd: 5, MinutesInAdvance: 30, LocalTimezone: "UTC", StartDate: "2023-10-01", TimeFrom: "09:00", TimeTo: "17:00", Mon: true, Tue: true, Wed: true, Thu: true, Fri: true, Sat: false, Sun: false, Updated: &updated},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/scheduled_scaling/?limit=5&name__icontains=weekend", mock.AnythingOfType("*config.ScheduledScalingListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ScheduledScalingListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/scheduled_scaling/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ScheduledScalingListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ScheduledScalingListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -117,8 +117,8 @@ func TestService_GetScheduledScaling(t *testing.T) {
 		Updated:            &updated,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/scheduled_scaling/1/", mock.AnythingOfType("*config.ScheduledScaling")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ScheduledScaling)
+	client.On("GetJSON", t.Context(), "configuration/v1/scheduled_scaling/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ScheduledScaling")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ScheduledScaling)
 		*result = *expectedScheduledScaling
 	})
 

--- a/config/sip_credential.go
+++ b/config/sip_credential.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListSIPCredentials(ctx context.Context, opts *ListOptions) (*SIPCredentialListResponse, error) {
 	endpoint := "configuration/v1/sip_credential/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result SIPCredentialListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetSIPCredential(ctx context.Context, id int) (*SIPCredential,
 	endpoint := fmt.Sprintf("configuration/v1/sip_credential/%d/", id)
 
 	var result SIPCredential
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/sip_credential_test.go
+++ b/config/sip_credential_test.go
@@ -33,8 +33,8 @@ func TestService_ListSIPCredentials(t *testing.T) {
 						{ID: 2, Realm: "test.com", Username: "user2", Password: "password2"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/sip_credential/", mock.AnythingOfType("*config.SIPCredentialListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SIPCredentialListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/sip_credential/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SIPCredentialListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SIPCredentialListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListSIPCredentials(t *testing.T) {
 						{ID: 1, Realm: "example.com", Username: "user1", Password: "password1"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/sip_credential/?limit=5&name__icontains=user1", mock.AnythingOfType("*config.SIPCredentialListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SIPCredentialListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/sip_credential/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SIPCredentialListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SIPCredentialListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -93,8 +93,8 @@ func TestService_GetSIPCredential(t *testing.T) {
 		Password: "testpassword",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/sip_credential/1/", mock.AnythingOfType("*config.SIPCredential")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SIPCredential)
+	client.On("GetJSON", t.Context(), "configuration/v1/sip_credential/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SIPCredential")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SIPCredential)
 		*result = *expectedSIPCredential
 	})
 

--- a/config/sip_proxy.go
+++ b/config/sip_proxy.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListSIPProxies(ctx context.Context, opts *ListOptions) (*SIPProxyListResponse, error) {
 	endpoint := "configuration/v1/sip_proxy/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result SIPProxyListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetSIPProxy(ctx context.Context, id int) (*SIPProxy, error) {
 	endpoint := fmt.Sprintf("configuration/v1/sip_proxy/%d/", id)
 
 	var result SIPProxy
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/sip_proxy_test.go
+++ b/config/sip_proxy_test.go
@@ -35,8 +35,8 @@ func TestService_ListSIPProxies(t *testing.T) {
 						{ID: 2, Name: "secondary-proxy", Description: "Secondary SIP proxy", Address: "sip2.example.com", Port: &port2, Transport: "TCP"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/sip_proxy/", mock.AnythingOfType("*config.SIPProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SIPProxyListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/sip_proxy/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SIPProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SIPProxyListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -57,8 +57,8 @@ func TestService_ListSIPProxies(t *testing.T) {
 						{ID: 1, Name: "primary-proxy", Description: "Primary SIP proxy", Address: "sip1.example.com", Port: &port, Transport: "UDP"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/sip_proxy/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.SIPProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SIPProxyListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/sip_proxy/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SIPProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SIPProxyListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -99,8 +99,8 @@ func TestService_GetSIPProxy(t *testing.T) {
 		Transport:   "TLS",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/sip_proxy/1/", mock.AnythingOfType("*config.SIPProxy")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SIPProxy)
+	client.On("GetJSON", t.Context(), "configuration/v1/sip_proxy/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SIPProxy")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SIPProxy)
 		*result = *expectedSIPProxy
 	})
 

--- a/config/smtp_server.go
+++ b/config/smtp_server.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListSMTPServers(ctx context.Context, opts *ListOptions) (*SMTPServerListResponse, error) {
 	endpoint := "configuration/v1/smtp_server/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result SMTPServerListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetSMTPServer(ctx context.Context, id int) (*SMTPServer, error
 	endpoint := fmt.Sprintf("configuration/v1/smtp_server/%d/", id)
 
 	var result SMTPServer
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/smtp_server_test.go
+++ b/config/smtp_server_test.go
@@ -33,8 +33,8 @@ func TestService_ListSMTPServers(t *testing.T) {
 						{ID: 2, Name: "backup-smtp", Description: "Backup SMTP server", Address: "backup-smtp.example.com", Port: 25, ConnectionSecurity: "NONE", FromEmailAddress: "noreply@example.com"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/smtp_server/", mock.AnythingOfType("*config.SMTPServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SMTPServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/smtp_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SMTPServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SMTPServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListSMTPServers(t *testing.T) {
 						{ID: 1, Name: "primary-smtp", Description: "Primary SMTP server", Address: "smtp.example.com", Port: 587, ConnectionSecurity: "STARTTLS", FromEmailAddress: "noreply@example.com"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/smtp_server/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.SMTPServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SMTPServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/smtp_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SMTPServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SMTPServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -98,8 +98,8 @@ func TestService_GetSMTPServer(t *testing.T) {
 		ConnectionSecurity: "STARTTLS",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/smtp_server/1/", mock.AnythingOfType("*config.SMTPServer")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SMTPServer)
+	client.On("GetJSON", t.Context(), "configuration/v1/smtp_server/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SMTPServer")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SMTPServer)
 		*result = *expectedSMTPServer
 	})
 

--- a/config/snmp_network_management_system.go
+++ b/config/snmp_network_management_system.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListSnmpNetworkManagementSystems(ctx context.Context, opts *ListOptions) (*SnmpNetworkManagementSystemListResponse, error) {
 	endpoint := "configuration/v1/snmp_network_management_system/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result SnmpNetworkManagementSystemListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetSnmpNetworkManagementSystem(ctx context.Context, id int) (*
 	endpoint := fmt.Sprintf("configuration/v1/snmp_network_management_system/%d/", id)
 
 	var result SnmpNetworkManagementSystem
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/snmp_network_management_system_test.go
+++ b/config/snmp_network_management_system_test.go
@@ -33,8 +33,8 @@ func TestService_ListSnmpNetworkManagementSystems(t *testing.T) {
 						{ID: 2, Name: "backup-nms", Description: "Backup network management system", Address: "nms2.example.com", Port: 162, SnmpTrapCommunity: "private"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/snmp_network_management_system/", mock.AnythingOfType("*config.SnmpNetworkManagementSystemListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SnmpNetworkManagementSystemListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/snmp_network_management_system/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SnmpNetworkManagementSystemListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SnmpNetworkManagementSystemListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListSnmpNetworkManagementSystems(t *testing.T) {
 						{ID: 1, Name: "primary-nms", Description: "Primary network management system", Address: "nms1.example.com", Port: 162, SnmpTrapCommunity: "public"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/snmp_network_management_system/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.SnmpNetworkManagementSystemListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SnmpNetworkManagementSystemListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/snmp_network_management_system/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SnmpNetworkManagementSystemListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SnmpNetworkManagementSystemListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -95,8 +95,8 @@ func TestService_GetSnmpNetworkManagementSystem(t *testing.T) {
 		SnmpTrapCommunity: "test-community",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/snmp_network_management_system/1/", mock.AnythingOfType("*config.SnmpNetworkManagementSystem")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SnmpNetworkManagementSystem)
+	client.On("GetJSON", t.Context(), "configuration/v1/snmp_network_management_system/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SnmpNetworkManagementSystem")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SnmpNetworkManagementSystem)
 		*result = *expectedSnmpNMS
 	})
 

--- a/config/software_bundle.go
+++ b/config/software_bundle.go
@@ -9,21 +9,21 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 )
 
 // ListSoftwareBundles retrieves a list of software bundles (read-only)
 func (s *Service) ListSoftwareBundles(ctx context.Context, opts *ListOptions) (*SoftwareBundleListResponse, error) {
 	endpoint := "configuration/v1/software_bundle/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result SoftwareBundleListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -32,7 +32,7 @@ func (s *Service) GetSoftwareBundle(ctx context.Context, id int) (*SoftwareBundl
 	endpoint := fmt.Sprintf("configuration/v1/software_bundle/%d/", id)
 
 	var result SoftwareBundle
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/software_bundle_revision.go
+++ b/config/software_bundle_revision.go
@@ -9,21 +9,21 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 )
 
 // ListSoftwareBundleRevisions retrieves a list of software bundle revisions (read-only)
 func (s *Service) ListSoftwareBundleRevisions(ctx context.Context, opts *ListOptions) (*SoftwareBundleRevisionListResponse, error) {
 	endpoint := "configuration/v1/software_bundle_revision/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result SoftwareBundleRevisionListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -32,6 +32,6 @@ func (s *Service) GetSoftwareBundleRevision(ctx context.Context, id int) (*Softw
 	endpoint := fmt.Sprintf("configuration/v1/software_bundle_revision/%d/", id)
 
 	var result SoftwareBundleRevision
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/config/software_bundle_revision_test.go
+++ b/config/software_bundle_revision_test.go
@@ -32,8 +32,8 @@ func TestService_ListSoftwareBundleRevisions(t *testing.T) {
 						{ID: 2, BundleType: "conferencing", Core: false, Revision: "v28.0.0", Version: "28.0.0"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/software_bundle_revision/", mock.AnythingOfType("*config.SoftwareBundleRevisionListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SoftwareBundleRevisionListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/software_bundle_revision/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SoftwareBundleRevisionListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SoftwareBundleRevisionListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -53,8 +53,8 @@ func TestService_ListSoftwareBundleRevisions(t *testing.T) {
 						{ID: 1, BundleType: "core", Core: true, Revision: "v27.4.1", Version: "27.4.1"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/software_bundle_revision/?limit=5&name__icontains=v27", mock.AnythingOfType("*config.SoftwareBundleRevisionListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SoftwareBundleRevisionListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/software_bundle_revision/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SoftwareBundleRevisionListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SoftwareBundleRevisionListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -94,8 +94,8 @@ func TestService_GetSoftwareBundleRevision(t *testing.T) {
 		ResourceURI: "/api/admin/configuration/v1/software_bundle_revision/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/software_bundle_revision/1/", mock.AnythingOfType("*config.SoftwareBundleRevision")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SoftwareBundleRevision)
+	client.On("GetJSON", t.Context(), "configuration/v1/software_bundle_revision/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SoftwareBundleRevision")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SoftwareBundleRevision)
 		*result = *expectedSoftwareBundleRevision
 	})
 

--- a/config/software_bundle_test.go
+++ b/config/software_bundle_test.go
@@ -34,8 +34,8 @@ func TestService_ListSoftwareBundles(t *testing.T) {
 						{ID: 2, BundleType: "conferencing", SelectedRevision: &revision2},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/software_bundle/", mock.AnythingOfType("*config.SoftwareBundleListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SoftwareBundleListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/software_bundle/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SoftwareBundleListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SoftwareBundleListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -56,8 +56,8 @@ func TestService_ListSoftwareBundles(t *testing.T) {
 						{ID: 1, BundleType: "core", SelectedRevision: &revision},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/software_bundle/?limit=5&name__icontains=core", mock.AnythingOfType("*config.SoftwareBundleListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SoftwareBundleListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/software_bundle/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SoftwareBundleListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SoftwareBundleListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -96,8 +96,8 @@ func TestService_GetSoftwareBundle(t *testing.T) {
 		ResourceURI:      "/api/admin/configuration/v1/software_bundle/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/software_bundle/1/", mock.AnythingOfType("*config.SoftwareBundle")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SoftwareBundle)
+	client.On("GetJSON", t.Context(), "configuration/v1/software_bundle/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SoftwareBundle")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SoftwareBundle)
 		*result = *expectedSoftwareBundle
 	})
 

--- a/config/ssh_authorized_key.go
+++ b/config/ssh_authorized_key.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListSSHAuthorizedKeys(ctx context.Context, opts *ListOptions) (*SSHAuthorizedKeyListResponse, error) {
 	endpoint := "configuration/v1/ssh_authorized_key/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result SSHAuthorizedKeyListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetSSHAuthorizedKey(ctx context.Context, id int) (*SSHAuthoriz
 	endpoint := fmt.Sprintf("configuration/v1/ssh_authorized_key/%d/", id)
 
 	var result SSHAuthorizedKey
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/ssh_authorized_key_test.go
+++ b/config/ssh_authorized_key_test.go
@@ -33,8 +33,8 @@ func TestService_ListSSHAuthorizedKeys(t *testing.T) {
 						{ID: 2, Keytype: "ssh-ed25519", Key: "AAAAC3NzaC1lZDI1NTE5AAAAID...", Comment: "user@example.com", Nodes: []string{"management", "conferencing"}},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ssh_authorized_key/", mock.AnythingOfType("*config.SSHAuthorizedKeyListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SSHAuthorizedKeyListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ssh_authorized_key/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SSHAuthorizedKeyListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SSHAuthorizedKeyListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListSSHAuthorizedKeys(t *testing.T) {
 						{ID: 1, Keytype: "ssh-rsa", Key: "AAAAB3NzaC1yc2EAAAADAQABAAABAQ...", Comment: "admin@example.com", Nodes: []string{"management"}},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/ssh_authorized_key/?limit=5&name__icontains=admin", mock.AnythingOfType("*config.SSHAuthorizedKeyListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SSHAuthorizedKeyListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/ssh_authorized_key/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SSHAuthorizedKeyListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SSHAuthorizedKeyListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -95,8 +95,8 @@ func TestService_GetSSHAuthorizedKey(t *testing.T) {
 		ResourceURI: "/api/admin/configuration/v1/ssh_authorized_key/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/ssh_authorized_key/1/", mock.AnythingOfType("*config.SSHAuthorizedKey")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SSHAuthorizedKey)
+	client.On("GetJSON", t.Context(), "configuration/v1/ssh_authorized_key/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SSHAuthorizedKey")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SSHAuthorizedKey)
 		*result = *expectedSSHAuthorizedKey
 	})
 

--- a/config/static_route.go
+++ b/config/static_route.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListStaticRoutes(ctx context.Context, opts *ListOptions) (*StaticRouteListResponse, error) {
 	endpoint := "configuration/v1/static_route/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result StaticRouteListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetStaticRoute(ctx context.Context, id int) (*StaticRoute, err
 	endpoint := fmt.Sprintf("configuration/v1/static_route/%d/", id)
 
 	var result StaticRoute
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/static_route_test.go
+++ b/config/static_route_test.go
@@ -33,8 +33,8 @@ func TestService_ListStaticRoutes(t *testing.T) {
 						{ID: 2, Name: "route-2", Address: "172.16.0.0", Prefix: 16, Gateway: "192.168.1.1"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/static_route/", mock.AnythingOfType("*config.StaticRouteListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*StaticRouteListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/static_route/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.StaticRouteListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*StaticRouteListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListStaticRoutes(t *testing.T) {
 						{ID: 1, Name: "test-route", Address: "10.0.0.0", Prefix: 24, Gateway: "192.168.1.1"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/static_route/?limit=2&name__icontains=route", mock.AnythingOfType("*config.StaticRouteListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*StaticRouteListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/static_route/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.StaticRouteListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*StaticRouteListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -94,8 +94,8 @@ func TestService_GetStaticRoute(t *testing.T) {
 		Gateway: "192.168.1.1",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/static_route/1/", mock.AnythingOfType("*config.StaticRoute")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*StaticRoute)
+	client.On("GetJSON", t.Context(), "configuration/v1/static_route/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.StaticRoute")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*StaticRoute)
 		*result = *expectedRoute
 	})
 

--- a/config/stun_server.go
+++ b/config/stun_server.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListSTUNServers(ctx context.Context, opts *ListOptions) (*STUNServerListResponse, error) {
 	endpoint := "configuration/v1/stun_server/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result STUNServerListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetSTUNServer(ctx context.Context, id int) (*STUNServer, error
 	endpoint := fmt.Sprintf("configuration/v1/stun_server/%d/", id)
 
 	var result STUNServer
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/stun_server_test.go
+++ b/config/stun_server_test.go
@@ -33,8 +33,8 @@ func TestService_ListSTUNServers(t *testing.T) {
 						{ID: 2, Name: "backup-stun", Description: "Backup STUN server", Address: "stun-backup.example.com", Port: 3478},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/stun_server/", mock.AnythingOfType("*config.STUNServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*STUNServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/stun_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.STUNServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*STUNServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListSTUNServers(t *testing.T) {
 						{ID: 1, Name: "primary-stun", Description: "Primary STUN server", Address: "stun.example.com", Port: 3478},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/stun_server/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.STUNServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*STUNServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/stun_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.STUNServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*STUNServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -95,8 +95,8 @@ func TestService_GetSTUNServer(t *testing.T) {
 		ResourceURI: "/api/admin/configuration/v1/stun_server/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/stun_server/1/", mock.AnythingOfType("*config.STUNServer")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*STUNServer)
+	client.On("GetJSON", t.Context(), "configuration/v1/stun_server/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.STUNServer")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*STUNServer)
 		*result = *expectedSTUNServer
 	})
 

--- a/config/syslog_server.go
+++ b/config/syslog_server.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListSyslogServers(ctx context.Context, opts *ListOptions) (*SyslogServerListResponse, error) {
 	endpoint := "configuration/v1/syslog_server/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result SyslogServerListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetSyslogServer(ctx context.Context, id int) (*SyslogServer, e
 	endpoint := fmt.Sprintf("configuration/v1/syslog_server/%d/", id)
 
 	var result SyslogServer
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/syslog_server_test.go
+++ b/config/syslog_server_test.go
@@ -33,8 +33,8 @@ func TestService_ListSyslogServers(t *testing.T) {
 						{ID: 2, Address: "syslog.example.com", Port: 6514, Transport: "tls", Description: "Remote syslog server"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/syslog_server/", mock.AnythingOfType("*config.SyslogServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SyslogServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/syslog_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SyslogServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SyslogServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListSyslogServers(t *testing.T) {
 						{ID: 1, Address: "192.168.1.100", Port: 514, Transport: "udp", Description: "Main syslog server"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/syslog_server/?limit=5&name__icontains=main", mock.AnythingOfType("*config.SyslogServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SyslogServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/syslog_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SyslogServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SyslogServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -97,8 +97,8 @@ func TestService_GetSyslogServer(t *testing.T) {
 		WebLog:      false,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/syslog_server/1/", mock.AnythingOfType("*config.SyslogServer")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SyslogServer)
+	client.On("GetJSON", t.Context(), "configuration/v1/syslog_server/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SyslogServer")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SyslogServer)
 		*result = *expectedServer
 	})
 

--- a/config/system_backup.go
+++ b/config/system_backup.go
@@ -8,21 +8,21 @@ package config
 
 import (
 	"context"
+	"net/url"
 )
 
 // ListSystemBackups retrieves a list of system backups (read-only)
 func (s *Service) ListSystemBackups(ctx context.Context, opts *ListOptions) (*SystemBackupListResponse, error) {
 	endpoint := "configuration/v1/system_backup/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result SystemBackupListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -31,7 +31,7 @@ func (s *Service) GetSystemBackup(ctx context.Context, filename string) (*System
 	endpoint := "configuration/v1/system_backup/" + filename + "/"
 
 	var result SystemBackup
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/system_backup_test.go
+++ b/config/system_backup_test.go
@@ -35,8 +35,8 @@ func TestService_ListSystemBackups(t *testing.T) {
 						{Filename: "backup-20231202.tar.gz", Date: date2, Build: "28.0.0.1235", Version: "28.0.0", Size: 2097152},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/system_backup/", mock.AnythingOfType("*config.SystemBackupListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SystemBackupListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/system_backup/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SystemBackupListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SystemBackupListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -57,8 +57,8 @@ func TestService_ListSystemBackups(t *testing.T) {
 						{Filename: "backup-20231201.tar.gz", Date: date, Build: "27.4.1.1234", Version: "27.4.1", Size: 1048576},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/system_backup/?limit=5&name__icontains=20231201", mock.AnythingOfType("*config.SystemBackupListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SystemBackupListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/system_backup/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SystemBackupListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SystemBackupListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -101,8 +101,8 @@ func TestService_GetSystemBackup(t *testing.T) {
 		ResourceURI: "/api/admin/configuration/v1/system_backup/" + filename + "/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/system_backup/"+filename+"/", mock.AnythingOfType("*config.SystemBackup")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SystemBackup)
+	client.On("GetJSON", t.Context(), "configuration/v1/system_backup/"+filename+"/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SystemBackup")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SystemBackup)
 		*result = *expectedSystemBackup
 	})
 

--- a/config/system_location.go
+++ b/config/system_location.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListSystemLocations(ctx context.Context, opts *ListOptions) (*SystemLocationListResponse, error) {
 	endpoint := "configuration/v1/system_location/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result SystemLocationListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetSystemLocation(ctx context.Context, id int) (*SystemLocatio
 	endpoint := fmt.Sprintf("configuration/v1/system_location/%d/", id)
 
 	var result SystemLocation
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/system_location_test.go
+++ b/config/system_location_test.go
@@ -33,8 +33,8 @@ func TestService_ListSystemLocations(t *testing.T) {
 						{ID: 2, Name: "Location 2", Description: "Second location"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/system_location/", mock.AnythingOfType("*config.SystemLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SystemLocationListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/system_location/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SystemLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SystemLocationListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -55,8 +55,8 @@ func TestService_ListSystemLocations(t *testing.T) {
 						{ID: 1, Name: "Test Location", Description: "Test system location"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/system_location/?limit=3&name__icontains=location&offset=6", mock.AnythingOfType("*config.SystemLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SystemLocationListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/system_location/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SystemLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SystemLocationListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -94,8 +94,8 @@ func TestService_GetSystemLocation(t *testing.T) {
 		MTU:         1500,
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/system_location/1/", mock.AnythingOfType("*config.SystemLocation")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SystemLocation)
+	client.On("GetJSON", t.Context(), "configuration/v1/system_location/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SystemLocation")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SystemLocation)
 		*result = *expectedLocation
 	})
 

--- a/config/system_syncpoint.go
+++ b/config/system_syncpoint.go
@@ -24,6 +24,6 @@ func (s *Service) GetSystemSyncpoint(ctx context.Context, id int) (*SystemSyncpo
 	endpoint := fmt.Sprintf("configuration/v1/system_syncpoint/%d/", id)
 
 	var result SystemSyncpoint
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/config/system_syncpoint_test.go
+++ b/config/system_syncpoint_test.go
@@ -46,8 +46,8 @@ func TestService_GetSystemSyncpoint(t *testing.T) {
 		ResourceURI:  "/api/admin/configuration/v1/system_syncpoint/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/system_syncpoint/1/", mock.AnythingOfType("*config.SystemSyncpoint")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SystemSyncpoint)
+	client.On("GetJSON", t.Context(), "configuration/v1/system_syncpoint/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SystemSyncpoint")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SystemSyncpoint)
 		*result = *expectedSystemSyncpoint
 	})
 

--- a/config/system_tuneable.go
+++ b/config/system_tuneable.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListSystemTuneables(ctx context.Context, opts *ListOptions) (*SystemTuneableListResponse, error) {
 	endpoint := "configuration/v1/system_tuneable/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result SystemTuneableListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetSystemTuneable(ctx context.Context, id int) (*SystemTuneabl
 	endpoint := fmt.Sprintf("configuration/v1/system_tuneable/%d/", id)
 
 	var result SystemTuneable
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/system_tuneable_test.go
+++ b/config/system_tuneable_test.go
@@ -33,8 +33,8 @@ func TestService_ListSystemTuneables(t *testing.T) {
 						{ID: 2, Name: "timeout_interval", Setting: "30"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/system_tuneable/", mock.AnythingOfType("*config.SystemTuneableListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SystemTuneableListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/system_tuneable/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SystemTuneableListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SystemTuneableListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListSystemTuneables(t *testing.T) {
 						{ID: 1, Name: "max_connections", Setting: "1000"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/system_tuneable/?limit=5&name__icontains=max", mock.AnythingOfType("*config.SystemTuneableListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*SystemTuneableListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/system_tuneable/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SystemTuneableListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*SystemTuneableListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -93,8 +93,8 @@ func TestService_GetSystemTuneable(t *testing.T) {
 		ResourceURI: "/api/admin/configuration/v1/system_tuneable/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/system_tuneable/1/", mock.AnythingOfType("*config.SystemTuneable")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SystemTuneable)
+	client.On("GetJSON", t.Context(), "configuration/v1/system_tuneable/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.SystemTuneable")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SystemTuneable)
 		*result = *expectedSystemTuneable
 	})
 

--- a/config/teams_proxy.go
+++ b/config/teams_proxy.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListTeamsProxies(ctx context.Context, opts *ListOptions) (*TeamsProxyListResponse, error) {
 	endpoint := "configuration/v1/teams_proxy/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result TeamsProxyListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetTeamsProxy(ctx context.Context, id int) (*TeamsProxy, error
 	endpoint := fmt.Sprintf("configuration/v1/teams_proxy/%d/", id)
 
 	var result TeamsProxy
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/teams_proxy_test.go
+++ b/config/teams_proxy_test.go
@@ -38,8 +38,8 @@ func TestService_ListTeamsProxies(t *testing.T) {
 						{ID: 2, Name: "backup-teams-proxy", Description: "Backup Teams proxy", Address: "teams-proxy-backup.example.com", Port: 8443, AzureTenant: "tenant2", MinNumberOfInstances: 1, NotificationsEnabled: false},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/teams_proxy/", mock.AnythingOfType("*config.TeamsProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*TeamsProxyListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/teams_proxy/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.TeamsProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*TeamsProxyListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -63,8 +63,8 @@ func TestService_ListTeamsProxies(t *testing.T) {
 						{ID: 1, Name: "primary-teams-proxy", Description: "Primary Teams proxy", Address: "teams-proxy.example.com", Port: 8443, AzureTenant: "tenant1", EventhubID: &eventhubID, MinNumberOfInstances: 2, NotificationsEnabled: true, NotificationsQueue: &notificationsQueue, Updated: updated},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/teams_proxy/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.TeamsProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*TeamsProxyListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/teams_proxy/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.TeamsProxyListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*TeamsProxyListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -114,8 +114,8 @@ func TestService_GetTeamsProxy(t *testing.T) {
 		ResourceURI:          "/api/admin/configuration/v1/teams_proxy/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/teams_proxy/1/", mock.AnythingOfType("*config.TeamsProxy")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*TeamsProxy)
+	client.On("GetJSON", t.Context(), "configuration/v1/teams_proxy/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.TeamsProxy")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*TeamsProxy)
 		*result = *expectedTeamsProxy
 	})
 

--- a/config/telehealth_profile.go
+++ b/config/telehealth_profile.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListTelehealthProfiles(ctx context.Context, opts *ListOptions) (*TelehealthProfileListResponse, error) {
 	endpoint := "configuration/v1/telehealth_profile/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result TelehealthProfileListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetTelehealthProfile(ctx context.Context, id int) (*Telehealth
 	endpoint := fmt.Sprintf("configuration/v1/telehealth_profile/%d/", id)
 
 	var result TelehealthProfile
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/telehealth_profile_test.go
+++ b/config/telehealth_profile_test.go
@@ -33,8 +33,8 @@ func TestService_ListTelehealthProfiles(t *testing.T) {
 						{ID: 2, Name: "epic-profile-2", Description: "Epic Telehealth Profile 2", UUID: "123e4567-e89b-12d3-a456-426614174001", TelehealthCallDomain: "telehealth2.example.com", EpicEncryptionAlgorithm: "AES128", EpicEncryptionKeyType: "jwks"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/telehealth_profile/", mock.AnythingOfType("*config.TelehealthProfileListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*TelehealthProfileListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/telehealth_profile/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.TelehealthProfileListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*TelehealthProfileListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListTelehealthProfiles(t *testing.T) {
 						{ID: 1, Name: "epic-profile-1", Description: "Epic Telehealth Profile 1", UUID: "123e4567-e89b-12d3-a456-426614174000", TelehealthCallDomain: "telehealth.example.com", EpicEncryptionAlgorithm: "AES256", EpicEncryptionKeyType: "direct"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/telehealth_profile/?limit=5&name__icontains=epic-profile-1", mock.AnythingOfType("*config.TelehealthProfileListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*TelehealthProfileListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/telehealth_profile/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.TelehealthProfileListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*TelehealthProfileListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -111,8 +111,8 @@ func TestService_GetTelehealthProfile(t *testing.T) {
 		ResourceURI:                           "/api/admin/configuration/v1/telehealth_profile/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/telehealth_profile/1/", mock.AnythingOfType("*config.TelehealthProfile")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*TelehealthProfile)
+	client.On("GetJSON", t.Context(), "configuration/v1/telehealth_profile/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.TelehealthProfile")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*TelehealthProfile)
 		*result = *expectedTelehealthProfile
 	})
 

--- a/config/tls_certificate.go
+++ b/config/tls_certificate.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListTLSCertificates(ctx context.Context, opts *ListOptions) (*TLSCertificateListResponse, error) {
 	endpoint := "configuration/v1/tls_certificate/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result TLSCertificateListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetTLSCertificate(ctx context.Context, id int) (*TLSCertificat
 	endpoint := fmt.Sprintf("configuration/v1/tls_certificate/%d/", id)
 
 	var result TLSCertificate
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/tls_certificate_test.go
+++ b/config/tls_certificate_test.go
@@ -38,8 +38,8 @@ func TestService_ListTLSCertificates(t *testing.T) {
 						{ID: 2, Certificate: "-----BEGIN CERTIFICATE-----\nMIIC...", PrivateKey: "-----BEGIN PRIVATE KEY-----\nMIIF...", Nodes: []string{"conferencing"}, StartDate: startDate1, EndDate: endDate1, SubjectName: "CN=meeting.example.com"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/tls_certificate/", mock.AnythingOfType("*config.TLSCertificateListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*TLSCertificateListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/tls_certificate/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.TLSCertificateListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*TLSCertificateListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -63,8 +63,8 @@ func TestService_ListTLSCertificates(t *testing.T) {
 						{ID: 1, Certificate: "-----BEGIN CERTIFICATE-----\nMIIB...", PrivateKey: "-----BEGIN PRIVATE KEY-----\nMIIE...", Nodes: []string{"management"}, StartDate: startDate, EndDate: endDate, SubjectName: "CN=example.com", KeyID: &keyID},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/tls_certificate/?limit=5&name__icontains=example.com", mock.AnythingOfType("*config.TLSCertificateListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*TLSCertificateListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/tls_certificate/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.TLSCertificateListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*TLSCertificateListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -120,8 +120,8 @@ func TestService_GetTLSCertificate(t *testing.T) {
 		ResourceURI:          "/api/admin/configuration/v1/tls_certificate/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/tls_certificate/1/", mock.AnythingOfType("*config.TLSCertificate")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*TLSCertificate)
+	client.On("GetJSON", t.Context(), "configuration/v1/tls_certificate/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.TLSCertificate")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*TLSCertificate)
 		*result = *expectedTLSCertificate
 	})
 

--- a/config/turn_server.go
+++ b/config/turn_server.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListTURNServers(ctx context.Context, opts *ListOptions) (*TURNServerListResponse, error) {
 	endpoint := "configuration/v1/turn_server/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result TURNServerListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetTURNServer(ctx context.Context, id int) (*TURNServer, error
 	endpoint := fmt.Sprintf("configuration/v1/turn_server/%d/", id)
 
 	var result TURNServer
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/turn_server_test.go
+++ b/config/turn_server_test.go
@@ -35,8 +35,8 @@ func TestService_ListTURNServers(t *testing.T) {
 						{ID: 2, Name: "secure-turn", Description: "Secure TURN server", Address: "turns.example.com", Port: &port2, SecretKey: "secret123", ServerType: "external", TransportType: "tls"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/turn_server/", mock.AnythingOfType("*config.TURNServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*TURNServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/turn_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.TURNServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*TURNServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -57,8 +57,8 @@ func TestService_ListTURNServers(t *testing.T) {
 						{ID: 1, Name: "primary-turn", Description: "Primary TURN server", Address: "turn.example.com", Port: &port, Username: "turnuser", ServerType: "external", TransportType: "udp"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/turn_server/?limit=5&name__icontains=primary", mock.AnythingOfType("*config.TURNServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*TURNServerListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/turn_server/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.TURNServerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*TURNServerListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -104,8 +104,8 @@ func TestService_GetTURNServer(t *testing.T) {
 		ResourceURI:   "/api/admin/configuration/v1/turn_server/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/turn_server/1/", mock.AnythingOfType("*config.TURNServer")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*TURNServer)
+	client.On("GetJSON", t.Context(), "configuration/v1/turn_server/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.TURNServer")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*TURNServer)
 		*result = *expectedTURNServer
 	})
 

--- a/config/user_group.go
+++ b/config/user_group.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListUserGroups(ctx context.Context, opts *ListOptions) (*UserGroupListResponse, error) {
 	endpoint := "configuration/v1/user_group/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result UserGroupListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetUserGroup(ctx context.Context, id int) (*UserGroup, error) 
 	endpoint := fmt.Sprintf("configuration/v1/user_group/%d/", id)
 
 	var result UserGroup
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/user_group_entity_mapping.go
+++ b/config/user_group_entity_mapping.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListUserGroupEntityMappings(ctx context.Context, opts *ListOptions) (*UserGroupEntityMappingListResponse, error) {
 	endpoint := "configuration/v1/user_group_entity_mapping/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result UserGroupEntityMappingListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetUserGroupEntityMapping(ctx context.Context, id int) (*UserG
 	endpoint := fmt.Sprintf("configuration/v1/user_group_entity_mapping/%d/", id)
 
 	var result UserGroupEntityMapping
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/user_group_entity_mapping_test.go
+++ b/config/user_group_entity_mapping_test.go
@@ -33,8 +33,8 @@ func TestService_ListUserGroupEntityMappings(t *testing.T) {
 						{ID: 2, Description: "Location mapping for user group", EntityResourceURI: "/api/admin/configuration/v1/location/1/", UserGroup: "/api/admin/configuration/v1/user_group/2/"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/user_group_entity_mapping/", mock.AnythingOfType("*config.UserGroupEntityMappingListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*UserGroupEntityMappingListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/user_group_entity_mapping/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.UserGroupEntityMappingListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*UserGroupEntityMappingListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListUserGroupEntityMappings(t *testing.T) {
 						{ID: 1, Description: "Conference mapping for admin group", EntityResourceURI: "/api/admin/configuration/v1/conference/1/", UserGroup: "/api/admin/configuration/v1/user_group/1/"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/user_group_entity_mapping/?limit=5&name__icontains=conference", mock.AnythingOfType("*config.UserGroupEntityMappingListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*UserGroupEntityMappingListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/user_group_entity_mapping/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.UserGroupEntityMappingListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*UserGroupEntityMappingListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -94,8 +94,8 @@ func TestService_GetUserGroupEntityMapping(t *testing.T) {
 		ResourceURI:       "/api/admin/configuration/v1/user_group_entity_mapping/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/user_group_entity_mapping/1/", mock.AnythingOfType("*config.UserGroupEntityMapping")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*UserGroupEntityMapping)
+	client.On("GetJSON", t.Context(), "configuration/v1/user_group_entity_mapping/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.UserGroupEntityMapping")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*UserGroupEntityMapping)
 		*result = *expectedUserGroupEntityMapping
 	})
 

--- a/config/user_group_test.go
+++ b/config/user_group_test.go
@@ -33,8 +33,8 @@ func TestService_ListUserGroups(t *testing.T) {
 						{ID: 2, Name: "users", Description: "Regular users", Users: []string{"/api/admin/configuration/v1/end_user/3/"}, UserGroupEntityMappings: []string{}},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/user_group/", mock.AnythingOfType("*config.UserGroupListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*UserGroupListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/user_group/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.UserGroupListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*UserGroupListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -54,8 +54,8 @@ func TestService_ListUserGroups(t *testing.T) {
 						{ID: 1, Name: "administrators", Description: "System administrators", Users: []string{"/api/admin/configuration/v1/end_user/1/", "/api/admin/configuration/v1/end_user/2/"}, UserGroupEntityMappings: []string{"/api/admin/configuration/v1/user_group_entity_mapping/1/"}},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/user_group/?limit=5&name__icontains=admin", mock.AnythingOfType("*config.UserGroupListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*UserGroupListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/user_group/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.UserGroupListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*UserGroupListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -95,8 +95,8 @@ func TestService_GetUserGroup(t *testing.T) {
 		ResourceURI:             "/api/admin/configuration/v1/user_group/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/user_group/1/", mock.AnythingOfType("*config.UserGroup")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*UserGroup)
+	client.On("GetJSON", t.Context(), "configuration/v1/user_group/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.UserGroup")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*UserGroup)
 		*result = *expectedUserGroup
 	})
 

--- a/config/webapp_alias.go
+++ b/config/webapp_alias.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListWebappAliases(ctx context.Context, opts *ListOptions) (*WebappAliasListResponse, error) {
 	endpoint := "configuration/v1/webapp_alias/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result WebappAliasListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetWebappAlias(ctx context.Context, id int) (*WebappAlias, err
 	endpoint := fmt.Sprintf("configuration/v1/webapp_alias/%d/", id)
 
 	var result WebappAlias
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/webapp_alias_test.go
+++ b/config/webapp_alias_test.go
@@ -36,8 +36,8 @@ func TestService_ListWebappAliases(t *testing.T) {
 						{ID: 2, Slug: "admin", Description: "Admin interface", WebappType: "admin", IsEnabled: true, Bundle: &bundle1},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/webapp_alias/", mock.AnythingOfType("*config.WebappAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*WebappAliasListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/webapp_alias/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.WebappAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*WebappAliasListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -60,8 +60,8 @@ func TestService_ListWebappAliases(t *testing.T) {
 						{ID: 1, Slug: "meeting", Description: "Main meeting interface", WebappType: "meeting", IsEnabled: true, Bundle: &bundle, Branding: &branding},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/webapp_alias/?limit=5&name__icontains=meeting", mock.AnythingOfType("*config.WebappAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*WebappAliasListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/webapp_alias/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.WebappAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*WebappAliasListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -106,8 +106,8 @@ func TestService_GetWebappAlias(t *testing.T) {
 		ResourceURI: "/api/admin/configuration/v1/webapp_alias/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/webapp_alias/1/", mock.AnythingOfType("*config.WebappAlias")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*WebappAlias)
+	client.On("GetJSON", t.Context(), "configuration/v1/webapp_alias/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.WebappAlias")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*WebappAlias)
 		*result = *expectedWebappAlias
 	})
 

--- a/config/webapp_branding.go
+++ b/config/webapp_branding.go
@@ -8,6 +8,7 @@ package config
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -16,15 +17,14 @@ import (
 func (s *Service) ListWebappBrandings(ctx context.Context, opts *ListOptions) (*WebappBrandingListResponse, error) {
 	endpoint := "configuration/v1/webapp_branding/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result WebappBrandingListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -33,7 +33,7 @@ func (s *Service) GetWebappBranding(ctx context.Context, name string) (*WebappBr
 	endpoint := "configuration/v1/webapp_branding/" + name + "/"
 
 	var result WebappBranding
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/webapp_branding_test.go
+++ b/config/webapp_branding_test.go
@@ -37,8 +37,8 @@ func TestService_ListWebappBrandings(t *testing.T) {
 						{Name: "custom", Description: "Custom branding", UUID: "123e4567-e89b-12d3-a456-426614174001", WebappType: "meeting", IsDefault: false, BrandingFile: "custom.zip", LastUpdated: lastUpdated2},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/webapp_branding/", mock.AnythingOfType("*config.WebappBrandingListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*WebappBrandingListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/webapp_branding/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.WebappBrandingListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*WebappBrandingListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -60,8 +60,8 @@ func TestService_ListWebappBrandings(t *testing.T) {
 						{Name: "custom", Description: "Custom branding", UUID: "123e4567-e89b-12d3-a456-426614174001", WebappType: "meeting", IsDefault: false, BrandingFile: "custom.zip", LastUpdated: lastUpdated},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/webapp_branding/?limit=5&name__icontains=custom", mock.AnythingOfType("*config.WebappBrandingListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*WebappBrandingListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/webapp_branding/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.WebappBrandingListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*WebappBrandingListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -106,8 +106,8 @@ func TestService_GetWebappBranding(t *testing.T) {
 		ResourceURI:  "/api/admin/configuration/v1/webapp_branding/" + name + "/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/webapp_branding/"+name+"/", mock.AnythingOfType("*config.WebappBranding")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*WebappBranding)
+	client.On("GetJSON", t.Context(), "configuration/v1/webapp_branding/"+name+"/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.WebappBranding")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*WebappBranding)
 		*result = *expectedWebappBranding
 	})
 

--- a/config/worker_vm.go
+++ b/config/worker_vm.go
@@ -9,6 +9,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -17,15 +18,14 @@ import (
 func (s *Service) ListWorkerVMs(ctx context.Context, opts *ListOptions) (*WorkerVMListResponse, error) {
 	endpoint := "configuration/v1/worker_vm/"
 
+	var params *url.Values
 	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
+		urlValues := opts.ToURLValues()
+		params = &urlValues
 	}
 
 	var result WorkerVMListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
 	return &result, err
 }
 
@@ -34,7 +34,7 @@ func (s *Service) GetWorkerVM(ctx context.Context, id int) (*WorkerVM, error) {
 	endpoint := fmt.Sprintf("configuration/v1/worker_vm/%d/", id)
 
 	var result WorkerVM
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 

--- a/config/worker_vm_test.go
+++ b/config/worker_vm_test.go
@@ -33,8 +33,8 @@ func TestService_ListWorkerVMs(t *testing.T) {
 						{ID: 2, Name: "worker-2", Hostname: "worker2.example.com"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/worker_vm/", mock.AnythingOfType("*config.WorkerVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*WorkerVMListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/worker_vm/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.WorkerVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*WorkerVMListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -55,8 +55,8 @@ func TestService_ListWorkerVMs(t *testing.T) {
 						{ID: 1, Name: "test-worker", Hostname: "testworker.example.com"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "configuration/v1/worker_vm/?limit=2&name__icontains=worker&offset=4", mock.AnythingOfType("*config.WorkerVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*WorkerVMListResponse)
+				m.On("GetJSON", t.Context(), "configuration/v1/worker_vm/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.WorkerVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*WorkerVMListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -98,8 +98,8 @@ func TestService_GetWorkerVM(t *testing.T) {
 		SystemLocation: "/api/admin/configuration/v1/system_location/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "configuration/v1/worker_vm/1/", mock.AnythingOfType("*config.WorkerVM")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*WorkerVM)
+	client.On("GetJSON", t.Context(), "configuration/v1/worker_vm/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.WorkerVM")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*WorkerVM)
 		*result = *expectedVM
 	})
 

--- a/history/alarm.go
+++ b/history/alarm.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListAlarms(ctx context.Context, opts *ListOptions) (*AlarmListResponse, error) {
 	endpoint := "history/v1/alarm/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result AlarmListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetAlarm(ctx context.Context, id int) (*Alarm, error) {
 	endpoint := fmt.Sprintf("history/v1/alarm/%d/", id)
 
 	var result Alarm
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/history/alarm_test.go
+++ b/history/alarm_test.go
@@ -49,8 +49,8 @@ func TestService_ListAlarms(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", context.Background(), "history/v1/alarm/", mock.AnythingOfType("*history.AlarmListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*AlarmListResponse)
+	client.On("GetJSON", context.Background(), "history/v1/alarm/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.AlarmListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*AlarmListResponse)
 		*result = *expectedResponse
 	})
 
@@ -79,8 +79,8 @@ func TestService_GetAlarm(t *testing.T) {
 		ResourceURI: "/api/admin/history/v1/alarm/1/",
 	}
 
-	client.On("GetJSON", context.Background(), "history/v1/alarm/1/", mock.AnythingOfType("*history.Alarm")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*Alarm)
+	client.On("GetJSON", context.Background(), "history/v1/alarm/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.Alarm")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*Alarm)
 		*result = *expectedAlarm
 	})
 
@@ -124,11 +124,8 @@ func TestService_ListAlarms_WithOptions(t *testing.T) {
 		Objects: []Alarm{},
 	}
 
-	client.On("GetJSON", context.Background(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "history/v1/alarm/" &&
-			endpoint != "" // Allow any endpoint with parameters
-	}), mock.AnythingOfType("*history.AlarmListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*AlarmListResponse)
+	client.On("GetJSON", context.Background(), "history/v1/alarm/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.AlarmListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*AlarmListResponse)
 		*result = *expectedResponse
 	})
 
@@ -144,7 +141,7 @@ func TestService_ListAlarms_Error(t *testing.T) {
 	client := interfaces.NewHTTPClientMock()
 	service := New(client)
 
-	client.On("GetJSON", context.Background(), "history/v1/alarm/", mock.AnythingOfType("*history.AlarmListResponse")).Return(errors.New("server error"))
+	client.On("GetJSON", context.Background(), "history/v1/alarm/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.AlarmListResponse")).Return(errors.New("server error"))
 
 	_, err := service.ListAlarms(context.Background(), nil)
 	assert.Error(t, err)
@@ -157,7 +154,7 @@ func TestService_GetAlarm_NotFound(t *testing.T) {
 	client := interfaces.NewHTTPClientMock()
 	service := New(client)
 
-	client.On("GetJSON", context.Background(), "history/v1/alarm/999/", mock.AnythingOfType("*history.Alarm")).Return(errors.New("alarm not found"))
+	client.On("GetJSON", context.Background(), "history/v1/alarm/999/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.Alarm")).Return(errors.New("alarm not found"))
 
 	_, err := service.GetAlarm(context.Background(), 999)
 	assert.Error(t, err)

--- a/history/backplane.go
+++ b/history/backplane.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListBackplanes(ctx context.Context, opts *ListOptions) (*BackplaneListResponse, error) {
 	endpoint := "history/v1/backplane/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result BackplaneListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetBackplane(ctx context.Context, id string) (*Backplane, erro
 	endpoint := fmt.Sprintf("history/v1/backplane/%s/", id)
 
 	var result Backplane
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/history/backplane_media_stream.go
+++ b/history/backplane_media_stream.go
@@ -18,7 +18,7 @@ func (s *Service) ListBackplaneMediaStreams(ctx context.Context, opts *ListOptio
 	endpoint := "history/v1/backplane_media_stream/"
 
 	var result BackplaneMediaStreamListResponse
-	err := s.listEndpoint(ctx, endpoint, opts, &result)
+	err := s.listEndpointWithTimeFilter(ctx, endpoint, opts, &result)
 	return &result, err
 }
 

--- a/history/backplane_media_stream.go
+++ b/history/backplane_media_stream.go
@@ -17,21 +17,8 @@ import (
 func (s *Service) ListBackplaneMediaStreams(ctx context.Context, opts *ListOptions) (*BackplaneMediaStreamListResponse, error) {
 	endpoint := "history/v1/backplane_media_stream/"
 
-	if opts != nil {
-		params := opts.BaseListOptions.ToURLValues()
-		if opts.StartTime != nil {
-			params.Set("start_time__gte", opts.StartTime.Format(time.RFC3339))
-		}
-		if opts.EndTime != nil {
-			params.Set("end_time__lt", opts.EndTime.Format(time.RFC3339))
-		}
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result BackplaneMediaStreamListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -40,7 +27,7 @@ func (s *Service) GetBackplaneMediaStream(ctx context.Context, id int) (*Backpla
 	endpoint := fmt.Sprintf("history/v1/backplane_media_stream/%d/", id)
 
 	var result BackplaneMediaStream
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 
@@ -66,9 +53,7 @@ func (s *Service) ListBackplaneMediaStreamsByBackplane(ctx context.Context, back
 		}
 	}
 
-	endpoint += "?" + params.Encode()
-
 	var result BackplaneMediaStreamListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, &params, &result)
 	return &result, err
 }

--- a/history/backplane_media_stream_test.go
+++ b/history/backplane_media_stream_test.go
@@ -61,8 +61,8 @@ func TestService_ListBackplaneMediaStreams(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", context.Background(), "history/v1/backplane_media_stream/", mock.AnythingOfType("*history.BackplaneMediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*BackplaneMediaStreamListResponse)
+	client.On("GetJSON", context.Background(), "history/v1/backplane_media_stream/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.BackplaneMediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*BackplaneMediaStreamListResponse)
 		*result = *expectedResponse
 	})
 
@@ -102,8 +102,8 @@ func TestService_GetBackplaneMediaStream(t *testing.T) {
 		ResourceURI:       "/api/admin/history/v1/backplane_media_stream/1/",
 	}
 
-	client.On("GetJSON", context.Background(), "history/v1/backplane_media_stream/1/", mock.AnythingOfType("*history.BackplaneMediaStream")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*BackplaneMediaStream)
+	client.On("GetJSON", context.Background(), "history/v1/backplane_media_stream/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.BackplaneMediaStream")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*BackplaneMediaStream)
 		*result = *expectedStream
 	})
 
@@ -143,10 +143,8 @@ func TestService_ListBackplaneMediaStreamsByBackplane(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", context.Background(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "history/v1/backplane_media_stream/"
-	}), mock.AnythingOfType("*history.BackplaneMediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*BackplaneMediaStreamListResponse)
+	client.On("GetJSON", context.Background(), "history/v1/backplane_media_stream/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.BackplaneMediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*BackplaneMediaStreamListResponse)
 		*result = *expectedResponse
 	})
 
@@ -190,10 +188,8 @@ func TestService_ListBackplaneMediaStreams_WithOptions(t *testing.T) {
 		Objects: []BackplaneMediaStream{},
 	}
 
-	client.On("GetJSON", context.Background(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "history/v1/backplane_media_stream/"
-	}), mock.AnythingOfType("*history.BackplaneMediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*BackplaneMediaStreamListResponse)
+	client.On("GetJSON", context.Background(), "history/v1/backplane_media_stream/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.BackplaneMediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*BackplaneMediaStreamListResponse)
 		*result = *expectedResponse
 	})
 
@@ -240,10 +236,8 @@ func TestService_ListBackplaneMediaStreamsByBackplane_WithOptions(t *testing.T) 
 		},
 	}
 
-	client.On("GetJSON", context.Background(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "history/v1/backplane_media_stream/"
-	}), mock.AnythingOfType("*history.BackplaneMediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*BackplaneMediaStreamListResponse)
+	client.On("GetJSON", context.Background(), "history/v1/backplane_media_stream/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.BackplaneMediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*BackplaneMediaStreamListResponse)
 		*result = *expectedResponse
 	})
 
@@ -259,7 +253,7 @@ func TestService_ListBackplaneMediaStreams_Error(t *testing.T) {
 	client := interfaces.NewHTTPClientMock()
 	service := New(client)
 
-	client.On("GetJSON", context.Background(), "history/v1/backplane_media_stream/", mock.AnythingOfType("*history.BackplaneMediaStreamListResponse")).Return(errors.New("server error"))
+	client.On("GetJSON", context.Background(), "history/v1/backplane_media_stream/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.BackplaneMediaStreamListResponse")).Return(errors.New("server error"))
 
 	_, err := service.ListBackplaneMediaStreams(context.Background(), nil)
 	assert.Error(t, err)
@@ -272,9 +266,7 @@ func TestService_ListBackplaneMediaStreamsByBackplane_Error(t *testing.T) {
 	client := interfaces.NewHTTPClientMock()
 	service := New(client)
 
-	client.On("GetJSON", context.Background(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "history/v1/backplane_media_stream/"
-	}), mock.AnythingOfType("*history.BackplaneMediaStreamListResponse")).Return(errors.New("server error"))
+	client.On("GetJSON", context.Background(), "history/v1/backplane_media_stream/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.BackplaneMediaStreamListResponse")).Return(errors.New("server error"))
 
 	_, err := service.ListBackplaneMediaStreamsByBackplane(context.Background(), "backplane-error", nil)
 	assert.Error(t, err)
@@ -287,7 +279,7 @@ func TestService_GetBackplaneMediaStream_NotFound(t *testing.T) {
 	client := interfaces.NewHTTPClientMock()
 	service := New(client)
 
-	client.On("GetJSON", context.Background(), "history/v1/backplane_media_stream/999/", mock.AnythingOfType("*history.BackplaneMediaStream")).Return(errors.New("backplane media stream not found"))
+	client.On("GetJSON", context.Background(), "history/v1/backplane_media_stream/999/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.BackplaneMediaStream")).Return(errors.New("backplane media stream not found"))
 
 	_, err := service.GetBackplaneMediaStream(context.Background(), 999)
 	assert.Error(t, err)

--- a/history/backplane_test.go
+++ b/history/backplane_test.go
@@ -52,8 +52,8 @@ func TestService_ListBackplanes(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", context.Background(), "history/v1/backplane/", mock.AnythingOfType("*history.BackplaneListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*BackplaneListResponse)
+	client.On("GetJSON", context.Background(), "history/v1/backplane/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.BackplaneListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*BackplaneListResponse)
 		*result = *expectedResponse
 	})
 
@@ -87,8 +87,8 @@ func TestService_GetBackplane(t *testing.T) {
 		ResourceURI:          "/api/admin/history/v1/backplane/test-backplane-1/",
 	}
 
-	client.On("GetJSON", context.Background(), "history/v1/backplane/test-backplane-1/", mock.AnythingOfType("*history.Backplane")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*Backplane)
+	client.On("GetJSON", context.Background(), "history/v1/backplane/test-backplane-1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.Backplane")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*Backplane)
 		*result = *expectedBackplane
 	})
 
@@ -132,10 +132,8 @@ func TestService_ListBackplanes_WithOptions(t *testing.T) {
 		Objects: []Backplane{},
 	}
 
-	client.On("GetJSON", context.Background(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "history/v1/backplane/"
-	}), mock.AnythingOfType("*history.BackplaneListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*BackplaneListResponse)
+	client.On("GetJSON", context.Background(), "history/v1/backplane/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.BackplaneListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*BackplaneListResponse)
 		*result = *expectedResponse
 	})
 
@@ -151,7 +149,7 @@ func TestService_ListBackplanes_Error(t *testing.T) {
 	client := interfaces.NewHTTPClientMock()
 	service := New(client)
 
-	client.On("GetJSON", context.Background(), "history/v1/backplane/", mock.AnythingOfType("*history.BackplaneListResponse")).Return(errors.New("server error"))
+	client.On("GetJSON", context.Background(), "history/v1/backplane/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.BackplaneListResponse")).Return(errors.New("server error"))
 
 	_, err := service.ListBackplanes(context.Background(), nil)
 	assert.Error(t, err)
@@ -164,7 +162,7 @@ func TestService_GetBackplane_NotFound(t *testing.T) {
 	client := interfaces.NewHTTPClientMock()
 	service := New(client)
 
-	client.On("GetJSON", context.Background(), "history/v1/backplane/nonexistent/", mock.AnythingOfType("*history.Backplane")).Return(errors.New("backplane not found"))
+	client.On("GetJSON", context.Background(), "history/v1/backplane/nonexistent/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.Backplane")).Return(errors.New("backplane not found"))
 
 	_, err := service.GetBackplane(context.Background(), "nonexistent")
 	assert.Error(t, err)

--- a/history/conference_record.go
+++ b/history/conference_record.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListConferenceRecords(ctx context.Context, opts *ListOptions) (*ConferenceRecordListResponse, error) {
 	endpoint := "history/v1/conference/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result ConferenceRecordListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetConferenceRecord(ctx context.Context, id int) (*ConferenceR
 	endpoint := fmt.Sprintf("history/v1/conference/%d/", id)
 
 	var result ConferenceRecord
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/history/conference_record_test.go
+++ b/history/conference_record_test.go
@@ -33,8 +33,8 @@ func TestService_ListConferences(t *testing.T) {
 						{ID: 2, Name: "Test ConferenceRecord 2", DurationSeconds: 1800},
 					},
 				}
-				m.On("GetJSON", t.Context(), "history/v1/conference/", mock.AnythingOfType("*history.ConferenceRecordListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ConferenceRecordListResponse)
+				m.On("GetJSON", t.Context(), "history/v1/conference/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.ConferenceRecordListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ConferenceRecordListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -60,10 +60,8 @@ func TestService_ListConferences(t *testing.T) {
 					},
 				}
 				// Note: The exact query string will vary based on time formatting
-				m.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-					return endpoint != "" && endpoint != "history/v1/conference/"
-				}), mock.AnythingOfType("*history.ConferenceRecordListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ConferenceRecordListResponse)
+				m.On("GetJSON", t.Context(), "history/v1/conference/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.ConferenceRecordListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ConferenceRecordListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -102,8 +100,8 @@ func TestService_GetConference(t *testing.T) {
 		TotalParticipants: 5,
 	}
 
-	client.On("GetJSON", t.Context(), "history/v1/conference/1/", mock.AnythingOfType("*history.ConferenceRecord")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ConferenceRecord)
+	client.On("GetJSON", t.Context(), "history/v1/conference/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.ConferenceRecord")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ConferenceRecord)
 		*result = *expectedConference
 	})
 

--- a/history/history.go
+++ b/history/history.go
@@ -12,6 +12,7 @@ package history
 import (
 	"context"
 	"net/url"
+	"time"
 
 	"github.com/pexip/go-infinity-sdk/v38/interfaces"
 )
@@ -32,6 +33,32 @@ func (s *Service) listEndpoint(ctx context.Context, endpoint string, opts *ListO
 	var params url.Values
 	if opts != nil {
 		params = opts.ToURLValues()
+	}
+	return s.client.GetJSON(ctx, endpoint, &params, result)
+}
+
+func (s *Service) listEndpointWithSearchField(ctx context.Context, endpoint string, opts *ListOptions, searchField string, result interface{}) error {
+	var params url.Values
+	if opts != nil {
+		if searchField != "" {
+			params = opts.ToURLValuesWithSearchField(searchField)
+		} else {
+			params = opts.ToURLValues()
+		}
+	}
+	return s.client.GetJSON(ctx, endpoint, &params, result)
+}
+
+func (s *Service) listEndpointWithTimeFilter(ctx context.Context, endpoint string, opts *ListOptions, result interface{}) error {
+	var params url.Values
+	if opts != nil {
+		params = opts.ToURLValues()
+		if opts.StartTime != nil {
+			params.Set("start_time__gte", opts.StartTime.Format(time.RFC3339))
+		}
+		if opts.EndTime != nil {
+			params.Set("end_time__lt", opts.EndTime.Format(time.RFC3339))
+		}
 	}
 	return s.client.GetJSON(ctx, endpoint, &params, result)
 }

--- a/history/history.go
+++ b/history/history.go
@@ -10,6 +10,9 @@
 package history
 
 import (
+	"context"
+	"net/url"
+
 	"github.com/pexip/go-infinity-sdk/v38/interfaces"
 )
 
@@ -23,4 +26,12 @@ func New(client interfaces.HTTPClient) *Service {
 	return &Service{
 		client: client,
 	}
+}
+
+func (s *Service) listEndpoint(ctx context.Context, endpoint string, opts *ListOptions, result interface{}) error {
+	var params url.Values
+	if opts != nil {
+		params = opts.ToURLValues()
+	}
+	return s.client.GetJSON(ctx, endpoint, &params, result)
 }

--- a/history/media_stream.go
+++ b/history/media_stream.go
@@ -19,7 +19,7 @@ func (s *Service) ListMediaStreams(ctx context.Context, opts *ListOptions) (*Med
 	endpoint := "history/v1/media_stream/"
 
 	var result MediaStreamListResponse
-	err := s.listEndpoint(ctx, endpoint, opts, &result)
+	err := s.listEndpointWithTimeFilter(ctx, endpoint, opts, &result)
 	return &result, err
 }
 

--- a/history/media_stream.go
+++ b/history/media_stream.go
@@ -18,21 +18,8 @@ import (
 func (s *Service) ListMediaStreams(ctx context.Context, opts *ListOptions) (*MediaStreamListResponse, error) {
 	endpoint := "history/v1/media_stream/"
 
-	if opts != nil {
-		params := opts.BaseListOptions.ToURLValues()
-		if opts.StartTime != nil {
-			params.Set("start_time__gte", opts.StartTime.Format(time.RFC3339))
-		}
-		if opts.EndTime != nil {
-			params.Set("end_time__lt", opts.EndTime.Format(time.RFC3339))
-		}
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result MediaStreamListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -41,7 +28,7 @@ func (s *Service) GetMediaStream(ctx context.Context, id int) (*MediaStream, err
 	endpoint := fmt.Sprintf("history/v1/media_stream/%d/", id)
 
 	var result MediaStream
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 
@@ -67,9 +54,7 @@ func (s *Service) ListMediaStreamsByParticipant(ctx context.Context, participant
 		}
 	}
 
-	endpoint += "?" + params.Encode()
-
 	var result MediaStreamListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, &params, &result)
 	return &result, err
 }

--- a/history/media_stream_test.go
+++ b/history/media_stream_test.go
@@ -34,8 +34,8 @@ func TestService_ListMediaStreams(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "history/v1/media_stream/", mock.AnythingOfType("*history.MediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MediaStreamListResponse)
+	client.On("GetJSON", t.Context(), "history/v1/media_stream/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.MediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MediaStreamListResponse)
 		*result = *expectedResponse
 	})
 
@@ -61,8 +61,8 @@ func TestService_GetMediaStream(t *testing.T) {
 		DurationSeconds: 1800,
 	}
 
-	client.On("GetJSON", t.Context(), "history/v1/media_stream/1/", mock.AnythingOfType("*history.MediaStream")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MediaStream)
+	client.On("GetJSON", t.Context(), "history/v1/media_stream/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.MediaStream")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MediaStream)
 		*result = *expectedStream
 	})
 
@@ -96,10 +96,8 @@ func TestService_ListMediaStreamsByParticipant(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "" && endpoint != "history/v1/media_stream/"
-	}), mock.AnythingOfType("*history.MediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MediaStreamListResponse)
+	client.On("GetJSON", t.Context(), "history/v1/media_stream/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.MediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MediaStreamListResponse)
 		*result = *expectedResponse
 	})
 
@@ -142,10 +140,8 @@ func TestService_ListMediaStreams_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "history/v1/media_stream/"
-	}), mock.AnythingOfType("*history.MediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MediaStreamListResponse)
+	client.On("GetJSON", t.Context(), "history/v1/media_stream/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.MediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MediaStreamListResponse)
 		*result = *expectedResponse
 	})
 
@@ -192,10 +188,8 @@ func TestService_ListMediaStreamsByParticipant_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "history/v1/media_stream/"
-	}), mock.AnythingOfType("*history.MediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MediaStreamListResponse)
+	client.On("GetJSON", t.Context(), "history/v1/media_stream/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.MediaStreamListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MediaStreamListResponse)
 		*result = *expectedResponse
 	})
 

--- a/history/participant.go
+++ b/history/participant.go
@@ -18,7 +18,7 @@ func (s *Service) ListParticipants(ctx context.Context, opts *ListOptions) (*Par
 	endpoint := "history/v1/participant/"
 
 	var result ParticipantListResponse
-	err := s.listEndpoint(ctx, endpoint, opts, &result)
+	err := s.listEndpointWithSearchField(ctx, endpoint, opts, "display_name__icontains", &result)
 	return &result, err
 }
 

--- a/history/participant.go
+++ b/history/participant.go
@@ -17,15 +17,8 @@ import (
 func (s *Service) ListParticipants(ctx context.Context, opts *ListOptions) (*ParticipantListResponse, error) {
 	endpoint := "history/v1/participant/"
 
-	if opts != nil {
-		params := opts.ToURLValuesWithSearchField("display_name__icontains")
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result ParticipantListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -34,7 +27,7 @@ func (s *Service) GetParticipant(ctx context.Context, id int) (*Participant, err
 	endpoint := fmt.Sprintf("history/v1/participant/%d/", id)
 
 	var result Participant
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 
@@ -54,9 +47,7 @@ func (s *Service) ListParticipantsByConference(ctx context.Context, conferenceID
 		}
 	}
 
-	endpoint += "?" + params.Encode()
-
 	var result ParticipantListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, &params, &result)
 	return &result, err
 }

--- a/history/participant_test.go
+++ b/history/participant_test.go
@@ -33,8 +33,8 @@ func TestService_ListParticipants(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "history/v1/participant/", mock.AnythingOfType("*history.ParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ParticipantListResponse)
+	client.On("GetJSON", t.Context(), "history/v1/participant/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.ParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ParticipantListResponse)
 		*result = *expectedResponse
 	})
 
@@ -59,8 +59,8 @@ func TestService_GetParticipant(t *testing.T) {
 		DisconnectReason: "normal",
 	}
 
-	client.On("GetJSON", t.Context(), "history/v1/participant/1/", mock.AnythingOfType("*history.Participant")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*Participant)
+	client.On("GetJSON", t.Context(), "history/v1/participant/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.Participant")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*Participant)
 		*result = *expectedParticipant
 	})
 
@@ -94,10 +94,8 @@ func TestService_ListParticipantsByConference(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "" && endpoint != "history/v1/participant/"
-	}), mock.AnythingOfType("*history.ParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ParticipantListResponse)
+	client.On("GetJSON", t.Context(), "history/v1/participant/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.ParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ParticipantListResponse)
 		*result = *expectedResponse
 	})
 
@@ -141,10 +139,8 @@ func TestService_ListParticipants_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "history/v1/participant/"
-	}), mock.AnythingOfType("*history.ParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ParticipantListResponse)
+	client.On("GetJSON", t.Context(), "history/v1/participant/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.ParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ParticipantListResponse)
 		*result = *expectedResponse
 	})
 
@@ -185,10 +181,8 @@ func TestService_ListParticipantsByConference_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "history/v1/participant/"
-	}), mock.AnythingOfType("*history.ParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ParticipantListResponse)
+	client.On("GetJSON", t.Context(), "history/v1/participant/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.ParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ParticipantListResponse)
 		*result = *expectedResponse
 	})
 

--- a/history/registration_alias.go
+++ b/history/registration_alias.go
@@ -16,7 +16,8 @@ func (s *Service) ListRegistrationAliases(ctx context.Context, opts *ListOptions
 	endpoint := "history/v1/registration_alias/"
 
 	var result RegistrationAliasListResponse
-	err := s.listEndpoint(ctx, endpoint, opts, &result)
+
+	err := s.listEndpointWithSearchField(ctx, endpoint, opts, "alias__icontains", &result)
 	return &result, err
 }
 

--- a/history/registration_alias.go
+++ b/history/registration_alias.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListRegistrationAliases(ctx context.Context, opts *ListOptions) (*RegistrationAliasListResponse, error) {
 	endpoint := "history/v1/registration_alias/"
 
-	if opts != nil {
-		params := opts.ToURLValuesWithSearchField("alias__icontains")
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result RegistrationAliasListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetRegistrationAlias(ctx context.Context, id int) (*Registrati
 	endpoint := fmt.Sprintf("history/v1/registration_alias/%d/", id)
 
 	var result RegistrationAlias
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/history/registration_alias_test.go
+++ b/history/registration_alias_test.go
@@ -51,8 +51,8 @@ func TestService_ListRegistrationAliases(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", context.Background(), "history/v1/registration_alias/", mock.AnythingOfType("*history.RegistrationAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*RegistrationAliasListResponse)
+	client.On("GetJSON", context.Background(), "history/v1/registration_alias/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.RegistrationAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*RegistrationAliasListResponse)
 		*result = *expectedResponse
 	})
 
@@ -84,8 +84,8 @@ func TestService_GetRegistrationAlias(t *testing.T) {
 		ResourceURI:    "/api/admin/history/v1/registration_alias/1/",
 	}
 
-	client.On("GetJSON", context.Background(), "history/v1/registration_alias/1/", mock.AnythingOfType("*history.RegistrationAlias")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*RegistrationAlias)
+	client.On("GetJSON", context.Background(), "history/v1/registration_alias/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.RegistrationAlias")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*RegistrationAlias)
 		*result = *expectedAlias
 	})
 
@@ -135,10 +135,8 @@ func TestService_ListRegistrationAliases_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", context.Background(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "history/v1/registration_alias/"
-	}), mock.AnythingOfType("*history.RegistrationAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*RegistrationAliasListResponse)
+	client.On("GetJSON", context.Background(), "history/v1/registration_alias/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.RegistrationAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*RegistrationAliasListResponse)
 		*result = *expectedResponse
 	})
 
@@ -155,7 +153,7 @@ func TestService_ListRegistrationAliases_Error(t *testing.T) {
 	client := interfaces.NewHTTPClientMock()
 	service := New(client)
 
-	client.On("GetJSON", context.Background(), "history/v1/registration_alias/", mock.AnythingOfType("*history.RegistrationAliasListResponse")).Return(errors.New("server error"))
+	client.On("GetJSON", context.Background(), "history/v1/registration_alias/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.RegistrationAliasListResponse")).Return(errors.New("server error"))
 
 	_, err := service.ListRegistrationAliases(context.Background(), nil)
 	assert.Error(t, err)
@@ -168,7 +166,7 @@ func TestService_GetRegistrationAlias_NotFound(t *testing.T) {
 	client := interfaces.NewHTTPClientMock()
 	service := New(client)
 
-	client.On("GetJSON", context.Background(), "history/v1/registration_alias/999/", mock.AnythingOfType("*history.RegistrationAlias")).Return(errors.New("registration alias not found"))
+	client.On("GetJSON", context.Background(), "history/v1/registration_alias/999/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.RegistrationAlias")).Return(errors.New("registration alias not found"))
 
 	_, err := service.GetRegistrationAlias(context.Background(), 999)
 	assert.Error(t, err)

--- a/history/workervm_status_event.go
+++ b/history/workervm_status_event.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListWorkerVMStatusEvents(ctx context.Context, opts *ListOptions) (*WorkerVMStatusEventListResponse, error) {
 	endpoint := "history/v1/workervm_status_event/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result WorkerVMStatusEventListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetWorkerVMStatusEvent(ctx context.Context, id int) (*WorkerVM
 	endpoint := fmt.Sprintf("history/v1/workervm_status_event/%d/", id)
 
 	var result WorkerVMStatusEvent
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/history/workervm_status_event_test.go
+++ b/history/workervm_status_event_test.go
@@ -58,8 +58,8 @@ func TestService_ListWorkerVMStatusEvents(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", context.Background(), "history/v1/workervm_status_event/", mock.AnythingOfType("*history.WorkerVMStatusEventListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*WorkerVMStatusEventListResponse)
+	client.On("GetJSON", context.Background(), "history/v1/workervm_status_event/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.WorkerVMStatusEventListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*WorkerVMStatusEventListResponse)
 		*result = *expectedResponse
 	})
 
@@ -98,8 +98,8 @@ func TestService_GetWorkerVMStatusEvent(t *testing.T) {
 		ResourceURI:                       "/api/admin/history/v1/workervm_status_event/1/",
 	}
 
-	client.On("GetJSON", context.Background(), "history/v1/workervm_status_event/1/", mock.AnythingOfType("*history.WorkerVMStatusEvent")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*WorkerVMStatusEvent)
+	client.On("GetJSON", context.Background(), "history/v1/workervm_status_event/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.WorkerVMStatusEvent")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*WorkerVMStatusEvent)
 		*result = *expectedEvent
 	})
 
@@ -149,10 +149,8 @@ func TestService_ListWorkerVMStatusEvents_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", context.Background(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "history/v1/workervm_status_event/"
-	}), mock.AnythingOfType("*history.WorkerVMStatusEventListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*WorkerVMStatusEventListResponse)
+	client.On("GetJSON", context.Background(), "history/v1/workervm_status_event/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.WorkerVMStatusEventListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*WorkerVMStatusEventListResponse)
 		*result = *expectedResponse
 	})
 
@@ -169,7 +167,7 @@ func TestService_ListWorkerVMStatusEvents_Error(t *testing.T) {
 	client := interfaces.NewHTTPClientMock()
 	service := New(client)
 
-	client.On("GetJSON", context.Background(), "history/v1/workervm_status_event/", mock.AnythingOfType("*history.WorkerVMStatusEventListResponse")).Return(errors.New("server error"))
+	client.On("GetJSON", context.Background(), "history/v1/workervm_status_event/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.WorkerVMStatusEventListResponse")).Return(errors.New("server error"))
 
 	_, err := service.ListWorkerVMStatusEvents(context.Background(), nil)
 	assert.Error(t, err)
@@ -182,7 +180,7 @@ func TestService_GetWorkerVMStatusEvent_NotFound(t *testing.T) {
 	client := interfaces.NewHTTPClientMock()
 	service := New(client)
 
-	client.On("GetJSON", context.Background(), "history/v1/workervm_status_event/999/", mock.AnythingOfType("*history.WorkerVMStatusEvent")).Return(errors.New("worker VM status event not found"))
+	client.On("GetJSON", context.Background(), "history/v1/workervm_status_event/999/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*history.WorkerVMStatusEvent")).Return(errors.New("worker VM status event not found"))
 
 	_, err := service.GetWorkerVMStatusEvent(context.Background(), 999)
 	assert.Error(t, err)

--- a/interfaces/client.go
+++ b/interfaces/client.go
@@ -10,6 +10,7 @@ package interfaces
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 )
@@ -18,7 +19,7 @@ import (
 // This interface allows for dependency injection and testing without import cycles.
 type HTTPClient interface {
 	// GetJSON performs a GET request and unmarshals the JSON response
-	GetJSON(ctx context.Context, endpoint string, result interface{}) error
+	GetJSON(ctx context.Context, endpoint string, queryParams *url.Values, result interface{}) error
 
 	// PostJSON performs a POST request with JSON body and unmarshals the JSON response
 	PostJSON(ctx context.Context, endpoint string, body interface{}, result interface{}) error

--- a/interfaces/mock.go
+++ b/interfaces/mock.go
@@ -8,6 +8,7 @@ package interfaces
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/pexip/go-infinity-sdk/v38/types"
 	"github.com/stretchr/testify/mock"
@@ -19,8 +20,8 @@ type HTTPClientMock struct {
 }
 
 // GetJSON performs a GET request and unmarshals the JSON response
-func (m *HTTPClientMock) GetJSON(ctx context.Context, endpoint string, result interface{}) error {
-	args := m.Called(ctx, endpoint, result)
+func (m *HTTPClientMock) GetJSON(ctx context.Context, endpoint string, queryParams *url.Values, result interface{}) error {
+	args := m.Called(ctx, endpoint, queryParams, result)
 	return args.Error(0)
 }
 

--- a/status/alarm.go
+++ b/status/alarm.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListAlarms(ctx context.Context, opts *ListOptions) (*AlarmListResponse, error) {
 	endpoint := "status/v1/alarm/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result AlarmListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetAlarm(ctx context.Context, id int) (*Alarm, error) {
 	endpoint := fmt.Sprintf("status/v1/alarm/%d/", id)
 
 	var result Alarm
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/alarm_test.go
+++ b/status/alarm_test.go
@@ -40,8 +40,8 @@ func TestService_ListAlarms(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/alarm/", mock.AnythingOfType("*status.AlarmListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*AlarmListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/alarm/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.AlarmListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*AlarmListResponse)
 		*result = *expectedResponse
 	})
 
@@ -77,10 +77,8 @@ func TestService_ListAlarms_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/alarm/"
-	}), mock.AnythingOfType("*status.AlarmListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*AlarmListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/alarm/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.AlarmListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*AlarmListResponse)
 		*result = *expectedResponse
 	})
 
@@ -105,8 +103,8 @@ func TestService_GetAlarm(t *testing.T) {
 		TimeRaised: &util.InfinityTime{Time: timeRaised},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/alarm/1/", mock.AnythingOfType("*status.Alarm")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*Alarm)
+	client.On("GetJSON", t.Context(), "status/v1/alarm/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.Alarm")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*Alarm)
 		*result = *expectedAlarm
 	})
 

--- a/status/backplane.go
+++ b/status/backplane.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListBackplanes(ctx context.Context, opts *ListOptions) (*BackplaneListResponse, error) {
 	endpoint := "status/v1/backplane/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result BackplaneListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetBackplane(ctx context.Context, id string) (*Backplane, erro
 	endpoint := fmt.Sprintf("status/v1/backplane/%s/", id)
 
 	var result Backplane
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/backplane_test.go
+++ b/status/backplane_test.go
@@ -38,8 +38,8 @@ func TestService_ListBackplanes(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/backplane/", mock.AnythingOfType("*status.BackplaneListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*BackplaneListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/backplane/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.BackplaneListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*BackplaneListResponse)
 		*result = *expectedResponse
 	})
 
@@ -73,8 +73,8 @@ func TestService_GetBackplane(t *testing.T) {
 		ResourceURI:          "/api/admin/status/v1/backplane/backplane-1/",
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/backplane/backplane-1/", mock.AnythingOfType("*status.Backplane")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*Backplane)
+	client.On("GetJSON", t.Context(), "status/v1/backplane/backplane-1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.Backplane")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*Backplane)
 		*result = *expectedBackplane
 	})
 
@@ -106,10 +106,8 @@ func TestService_ListBackplanes_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/backplane/"
-	}), mock.AnythingOfType("*status.BackplaneListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*BackplaneListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/backplane/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.BackplaneListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*BackplaneListResponse)
 		*result = *expectedResponse
 	})
 

--- a/status/backup_request.go
+++ b/status/backup_request.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListBackupRequests(ctx context.Context, opts *ListOptions) (*BackupRequestListResponse, error) {
 	endpoint := "status/v1/backup_request/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result BackupRequestListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetBackupRequest(ctx context.Context, id int) (*BackupRequest,
 	endpoint := fmt.Sprintf("status/v1/backup_request/%d/", id)
 
 	var result BackupRequest
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/backup_request_test.go
+++ b/status/backup_request_test.go
@@ -43,8 +43,8 @@ func TestService_ListBackupRequests(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/backup_request/", mock.AnythingOfType("*status.BackupRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*BackupRequestListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/backup_request/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.BackupRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*BackupRequestListResponse)
 		*result = *expectedResponse
 	})
 
@@ -82,8 +82,8 @@ func TestService_GetBackupRequest(t *testing.T) {
 		State:       "completed",
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/backup_request/1/", mock.AnythingOfType("*status.BackupRequest")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*BackupRequest)
+	client.On("GetJSON", t.Context(), "status/v1/backup_request/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.BackupRequest")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*BackupRequest)
 		*result = *expectedRequest
 	})
 
@@ -130,10 +130,8 @@ func TestService_ListBackupRequests_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/backup_request/"
-	}), mock.AnythingOfType("*status.BackupRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*BackupRequestListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/backup_request/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.BackupRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*BackupRequestListResponse)
 		*result = *expectedResponse
 	})
 

--- a/status/cloud_monitored_location.go
+++ b/status/cloud_monitored_location.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListCloudMonitoredLocations(ctx context.Context, opts *ListOptions) (*CloudMonitoredLocationListResponse, error) {
 	endpoint := "status/v1/cloud_monitored_location/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result CloudMonitoredLocationListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetCloudMonitoredLocation(ctx context.Context, id int) (*Cloud
 	endpoint := fmt.Sprintf("status/v1/cloud_monitored_location/%d/", id)
 
 	var result CloudMonitoredLocation
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/cloud_monitored_location_test.go
+++ b/status/cloud_monitored_location_test.go
@@ -56,8 +56,8 @@ func TestService_ListCloudMonitoredLocations(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/cloud_monitored_location/", mock.AnythingOfType("*status.CloudMonitoredLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*CloudMonitoredLocationListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/cloud_monitored_location/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.CloudMonitoredLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*CloudMonitoredLocationListResponse)
 		*result = *expectedResponse
 	})
 
@@ -93,8 +93,8 @@ func TestService_GetCloudMonitoredLocation(t *testing.T) {
 		ResourceURI:      "/api/admin/status/v1/cloud_monitored_location/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/cloud_monitored_location/1/", mock.AnythingOfType("*status.CloudMonitoredLocation")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*CloudMonitoredLocation)
+	client.On("GetJSON", t.Context(), "status/v1/cloud_monitored_location/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.CloudMonitoredLocation")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*CloudMonitoredLocation)
 		*result = *expectedLocation
 	})
 
@@ -146,10 +146,8 @@ func TestService_ListCloudMonitoredLocations_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/cloud_monitored_location/"
-	}), mock.AnythingOfType("*status.CloudMonitoredLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*CloudMonitoredLocationListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/cloud_monitored_location/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.CloudMonitoredLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*CloudMonitoredLocationListResponse)
 		*result = *expectedResponse
 	})
 

--- a/status/cloud_node.go
+++ b/status/cloud_node.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListCloudNodes(ctx context.Context, opts *ListOptions) (*CloudNodeListResponse, error) {
 	endpoint := "status/v1/cloud_node/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result CloudNodeListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetCloudNode(ctx context.Context, id string) (*CloudNode, erro
 	endpoint := fmt.Sprintf("status/v1/cloud_node/%s/", id)
 
 	var result CloudNode
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/cloud_node_test.go
+++ b/status/cloud_node_test.go
@@ -70,8 +70,8 @@ func TestService_ListCloudNodes(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/cloud_node/", mock.AnythingOfType("*status.CloudNodeListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*CloudNodeListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/cloud_node/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.CloudNodeListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*CloudNodeListResponse)
 		*result = *expectedResponse
 	})
 
@@ -123,8 +123,8 @@ func TestService_GetCloudNode(t *testing.T) {
 		WorkerVMConfigurationName:         strPtr("worker-vm-primary"),
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/cloud_node/i-1234567890abcdef0/", mock.AnythingOfType("*status.CloudNode")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*CloudNode)
+	client.On("GetJSON", t.Context(), "status/v1/cloud_node/i-1234567890abcdef0/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.CloudNode")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*CloudNode)
 		*result = *expectedNode
 	})
 
@@ -181,10 +181,8 @@ func TestService_ListCloudNodes_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/cloud_node/"
-	}), mock.AnythingOfType("*status.CloudNodeListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*CloudNodeListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/cloud_node/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.CloudNodeListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*CloudNodeListResponse)
 		*result = *expectedResponse
 	})
 

--- a/status/cloud_overflow_location.go
+++ b/status/cloud_overflow_location.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListCloudOverflowLocations(ctx context.Context, opts *ListOptions) (*CloudOverflowLocationListResponse, error) {
 	endpoint := "status/v1/cloud_overflow_location/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result CloudOverflowLocationListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetCloudOverflowLocation(ctx context.Context, id int) (*CloudO
 	endpoint := fmt.Sprintf("status/v1/cloud_overflow_location/%d/", id)
 
 	var result CloudOverflowLocation
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/cloud_overflow_location_test.go
+++ b/status/cloud_overflow_location_test.go
@@ -38,8 +38,8 @@ func TestService_ListCloudOverflowLocations(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/cloud_overflow_location/", mock.AnythingOfType("*status.CloudOverflowLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*CloudOverflowLocationListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/cloud_overflow_location/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.CloudOverflowLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*CloudOverflowLocationListResponse)
 		*result = *expectedResponse
 	})
 
@@ -88,10 +88,8 @@ func TestService_ListCloudOverflowLocations_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/cloud_overflow_location/"
-	}), mock.AnythingOfType("*status.CloudOverflowLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*CloudOverflowLocationListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/cloud_overflow_location/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.CloudOverflowLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*CloudOverflowLocationListResponse)
 		*result = *expectedResponse
 	})
 
@@ -122,8 +120,8 @@ func TestService_GetCloudOverflowLocation(t *testing.T) {
 		SystemLocationID: 103,
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/cloud_overflow_location/1/", mock.AnythingOfType("*status.CloudOverflowLocation")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*CloudOverflowLocation)
+	client.On("GetJSON", t.Context(), "status/v1/cloud_overflow_location/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.CloudOverflowLocation")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*CloudOverflowLocation)
 		*result = *expectedLocation
 	})
 

--- a/status/conference.go
+++ b/status/conference.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListConferences(ctx context.Context, opts *ListOptions) (*ConferenceListResponse, error) {
 	endpoint := "status/v1/conference/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result ConferenceListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetConference(ctx context.Context, id string) (*ConferenceStat
 	endpoint := fmt.Sprintf("status/v1/conference/%s/", id)
 
 	var result ConferenceStatus
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/conference_shard.go
+++ b/status/conference_shard.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListConferenceShards(ctx context.Context, opts *ListOptions) (*ConferenceShardListResponse, error) {
 	endpoint := "status/v1/conference_shard/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result ConferenceShardListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetConferenceShard(ctx context.Context, id string) (*Conferenc
 	endpoint := fmt.Sprintf("status/v1/conference_shard/%s/", id)
 
 	var result ConferenceShard
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/conference_shard_test.go
+++ b/status/conference_shard_test.go
@@ -59,8 +59,8 @@ func TestService_ListConferenceShards(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/conference_shard/", mock.AnythingOfType("*status.ConferenceShardListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ConferenceShardListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/conference_shard/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ConferenceShardListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ConferenceShardListResponse)
 		*result = *expectedResponse
 	})
 
@@ -98,8 +98,8 @@ func TestService_GetConferenceShard(t *testing.T) {
 		TranscodingEnabled: true,
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/conference_shard/shard-primary/", mock.AnythingOfType("*status.ConferenceShard")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ConferenceShard)
+	client.On("GetJSON", t.Context(), "status/v1/conference_shard/shard-primary/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ConferenceShard")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ConferenceShard)
 		*result = *expectedShard
 	})
 
@@ -157,10 +157,8 @@ func TestService_ListConferenceShards_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/conference_shard/"
-	}), mock.AnythingOfType("*status.ConferenceShardListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ConferenceShardListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/conference_shard/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ConferenceShardListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ConferenceShardListResponse)
 		*result = *expectedResponse
 	})
 

--- a/status/conference_sync.go
+++ b/status/conference_sync.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListConferenceSyncs(ctx context.Context, opts *ListOptions) (*ConferenceSyncListResponse, error) {
 	endpoint := "status/v1/conference_sync/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result ConferenceSyncListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetConferenceSync(ctx context.Context, id int) (*ConferenceSyn
 	endpoint := fmt.Sprintf("status/v1/conference_sync/%d/", id)
 
 	var result ConferenceSync
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/conference_sync_test.go
+++ b/status/conference_sync_test.go
@@ -55,8 +55,8 @@ func TestService_ListConferenceSyncs(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/conference_sync/", mock.AnythingOfType("*status.ConferenceSyncListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ConferenceSyncListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/conference_sync/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ConferenceSyncListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ConferenceSyncListResponse)
 		*result = *expectedResponse
 	})
 
@@ -114,10 +114,8 @@ func TestService_ListConferenceSyncs_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/conference_sync/"
-	}), mock.AnythingOfType("*status.ConferenceSyncListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ConferenceSyncListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/conference_sync/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ConferenceSyncListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ConferenceSyncListResponse)
 		*result = *expectedResponse
 	})
 
@@ -158,8 +156,8 @@ func TestService_GetConferenceSync(t *testing.T) {
 		VMRsUpdated:              0,
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/conference_sync/1/", mock.AnythingOfType("*status.ConferenceSync")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ConferenceSync)
+	client.On("GetJSON", t.Context(), "status/v1/conference_sync/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ConferenceSync")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ConferenceSync)
 		*result = *expectedSync
 	})
 

--- a/status/conference_test.go
+++ b/status/conference_test.go
@@ -31,8 +31,8 @@ func TestService_ListConferences(t *testing.T) {
 						{ID: "2", Name: "Test Conference 2", IsStarted: false, ServiceType: "conference"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "status/v1/conference/", mock.AnythingOfType("*status.ConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ConferenceListResponse)
+				m.On("GetJSON", t.Context(), "status/v1/conference/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ConferenceListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -50,8 +50,8 @@ func TestService_ListConferences(t *testing.T) {
 						{ID: "3", Name: "Test Conference 3", IsStarted: true, ServiceType: "conference"},
 					},
 				}
-				m.On("GetJSON", t.Context(), "status/v1/conference/?limit=5&offset=10", mock.AnythingOfType("*status.ConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
-					result := args.Get(2).(*ConferenceListResponse)
+				m.On("GetJSON", t.Context(), "status/v1/conference/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ConferenceListResponse")).Return(nil).Run(func(args mock.Arguments) {
+					result := args.Get(3).(*ConferenceListResponse)
 					*result = *expectedResponse
 				})
 			},
@@ -89,8 +89,8 @@ func TestService_GetConference(t *testing.T) {
 		IsStarted:   true,
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/conference/1/", mock.AnythingOfType("*status.ConferenceStatus")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ConferenceStatus)
+	client.On("GetJSON", t.Context(), "status/v1/conference/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ConferenceStatus")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ConferenceStatus)
 		*result = *expectedConference
 	})
 

--- a/status/exchange_scheduler.go
+++ b/status/exchange_scheduler.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListExchangeSchedulers(ctx context.Context, opts *ListOptions) (*ExchangeSchedulerListResponse, error) {
 	endpoint := "status/v1/exchange_scheduler/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result ExchangeSchedulerListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetExchangeScheduler(ctx context.Context, id int) (*ExchangeSc
 	endpoint := fmt.Sprintf("status/v1/exchange_scheduler/%d/", id)
 
 	var result ExchangeScheduler
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/exchange_scheduler_test.go
+++ b/status/exchange_scheduler_test.go
@@ -39,8 +39,8 @@ func TestService_ListExchangeSchedulers(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/exchange_scheduler/", mock.AnythingOfType("*status.ExchangeSchedulerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ExchangeSchedulerListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/exchange_scheduler/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ExchangeSchedulerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ExchangeSchedulerListResponse)
 		*result = *expectedResponse
 	})
 
@@ -83,10 +83,8 @@ func TestService_ListExchangeSchedulers_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/exchange_scheduler/"
-	}), mock.AnythingOfType("*status.ExchangeSchedulerListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ExchangeSchedulerListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/exchange_scheduler/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ExchangeSchedulerListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ExchangeSchedulerListResponse)
 		*result = *expectedResponse
 	})
 
@@ -112,8 +110,8 @@ func TestService_GetExchangeScheduler(t *testing.T) {
 		ResourceURI:         "/api/admin/status/v1/exchange_scheduler/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/exchange_scheduler/1/", mock.AnythingOfType("*status.ExchangeScheduler")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ExchangeScheduler)
+	client.On("GetJSON", t.Context(), "status/v1/exchange_scheduler/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ExchangeScheduler")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ExchangeScheduler)
 		*result = *expectedScheduler
 	})
 

--- a/status/licensing.go
+++ b/status/licensing.go
@@ -19,7 +19,7 @@ func (s *Service) GetLicensing(ctx context.Context) (*Licensing, error) {
 	endpoint := "status/v1/licensing/"
 
 	var result LicensingResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/status/licensing_test.go
+++ b/status/licensing_test.go
@@ -42,8 +42,8 @@ func TestService_GetLicensing(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/licensing/", mock.AnythingOfType("*status.LicensingResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*LicensingResponse)
+	client.On("GetJSON", t.Context(), "status/v1/licensing/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.LicensingResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*LicensingResponse)
 		*result = *expectedLicensingResponse
 	})
 
@@ -80,8 +80,8 @@ func TestService_GetLicensing_EmptyResponse(t *testing.T) {
 		Objects: []Licensing{},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/licensing/", mock.AnythingOfType("*status.LicensingResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*LicensingResponse)
+	client.On("GetJSON", t.Context(), "status/v1/licensing/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.LicensingResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*LicensingResponse)
 		*result = *emptyLicensing
 	})
 

--- a/status/management_vm.go
+++ b/status/management_vm.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListManagementVMs(ctx context.Context, opts *ListOptions) (*ManagementVMListResponse, error) {
 	endpoint := "status/v1/management_vm/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result ManagementVMListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetManagementVM(ctx context.Context, id int) (*ManagementVM, e
 	endpoint := fmt.Sprintf("status/v1/management_vm/%d/", id)
 
 	var result ManagementVM
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/management_vm_test.go
+++ b/status/management_vm_test.go
@@ -44,8 +44,8 @@ func TestService_ListManagementVMs(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/management_vm/", mock.AnythingOfType("*status.ManagementVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ManagementVMListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/management_vm/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ManagementVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ManagementVMListResponse)
 		*result = *expectedResponse
 	})
 
@@ -79,8 +79,8 @@ func TestService_GetManagementVM(t *testing.T) {
 		ResourceURI:          "/api/admin/status/v1/management_vm/1/",
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/management_vm/1/", mock.AnythingOfType("*status.ManagementVM")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ManagementVM)
+	client.On("GetJSON", t.Context(), "status/v1/management_vm/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ManagementVM")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ManagementVM)
 		*result = *expectedVM
 	})
 
@@ -117,10 +117,8 @@ func TestService_ListManagementVMs_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/management_vm/"
-	}), mock.AnythingOfType("*status.ManagementVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ManagementVMListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/management_vm/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ManagementVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ManagementVMListResponse)
 		*result = *expectedResponse
 	})
 

--- a/status/mjx_endpoint.go
+++ b/status/mjx_endpoint.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListMJXEndpoints(ctx context.Context, opts *ListOptions) (*MJXEndpointListResponse, error) {
 	endpoint := "status/v1/mjx_endpoint/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result MJXEndpointListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetMJXEndpoint(ctx context.Context, id int) (*MJXEndpoint, err
 	endpoint := fmt.Sprintf("status/v1/mjx_endpoint/%d/", id)
 
 	var result MJXEndpoint
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/mjx_endpoint_test.go
+++ b/status/mjx_endpoint_test.go
@@ -50,8 +50,8 @@ func TestService_ListMJXEndpoints(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/mjx_endpoint/", mock.AnythingOfType("*status.MJXEndpointListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MJXEndpointListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/mjx_endpoint/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.MJXEndpointListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MJXEndpointListResponse)
 		*result = *expectedResponse
 	})
 
@@ -96,8 +96,8 @@ func TestService_GetMJXEndpoint(t *testing.T) {
 		RoomEmail:          "room-primary@example.com",
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/mjx_endpoint/1/", mock.AnythingOfType("*status.MJXEndpoint")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MJXEndpoint)
+	client.On("GetJSON", t.Context(), "status/v1/mjx_endpoint/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.MJXEndpoint")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MJXEndpoint)
 		*result = *expectedEndpoint
 	})
 
@@ -143,10 +143,8 @@ func TestService_ListMJXEndpoints_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/mjx_endpoint/"
-	}), mock.AnythingOfType("*status.MJXEndpointListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MJXEndpointListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/mjx_endpoint/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.MJXEndpointListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MJXEndpointListResponse)
 		*result = *expectedResponse
 	})
 

--- a/status/mjx_meeting.go
+++ b/status/mjx_meeting.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListMJXMeetings(ctx context.Context, opts *ListOptions) (*MJXMeetingListResponse, error) {
 	endpoint := "status/v1/mjx_meeting/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result MJXMeetingListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetMJXMeeting(ctx context.Context, id string) (*MJXMeeting, er
 	endpoint := fmt.Sprintf("status/v1/mjx_meeting/%s/", id)
 
 	var result MJXMeeting
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/mjx_meeting_test.go
+++ b/status/mjx_meeting_test.go
@@ -45,8 +45,8 @@ func TestService_ListMJXMeetings(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/mjx_meeting/", mock.AnythingOfType("*status.MJXMeetingListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MJXMeetingListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/mjx_meeting/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.MJXMeetingListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MJXMeetingListResponse)
 		*result = *expectedResponse
 	})
 
@@ -101,10 +101,8 @@ func TestService_ListMJXMeetings_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/mjx_meeting/"
-	}), mock.AnythingOfType("*status.MJXMeetingListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MJXMeetingListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/mjx_meeting/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.MJXMeetingListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MJXMeetingListResponse)
 		*result = *expectedResponse
 	})
 
@@ -146,8 +144,8 @@ func TestService_GetMJXMeeting(t *testing.T) {
 		WorkerID:                     0,
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/mjx_meeting/meeting-456/", mock.AnythingOfType("*status.MJXMeeting")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*MJXMeeting)
+	client.On("GetJSON", t.Context(), "status/v1/mjx_meeting/meeting-456/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.MJXMeeting")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*MJXMeeting)
 		*result = *expectedMeeting
 	})
 

--- a/status/participant.go
+++ b/status/participant.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListParticipants(ctx context.Context, opts *ListOptions) (*ParticipantListResponse, error) {
 	endpoint := "status/v1/participant/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result ParticipantListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetParticipant(ctx context.Context, uuid string) (*Participant
 	endpoint := fmt.Sprintf("status/v1/participant/%s/", uuid)
 
 	var result Participant
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/participant_test.go
+++ b/status/participant_test.go
@@ -121,8 +121,8 @@ func TestService_ListParticipants(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/participant/", mock.AnythingOfType("*status.ParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ParticipantListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/participant/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ParticipantListResponse)
 		*result = *expectedResponse
 	})
 
@@ -201,10 +201,8 @@ func TestService_ListParticipants_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/participant/"
-	}), mock.AnythingOfType("*status.ParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*ParticipantListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/participant/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.ParticipantListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ParticipantListResponse)
 		*result = *expectedResponse
 	})
 
@@ -269,8 +267,8 @@ func TestService_GetParticipant(t *testing.T) {
 		Vendor:                  "Mozilla/5.0",
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/participant/participant-1/", mock.AnythingOfType("*status.Participant")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*Participant)
+	client.On("GetJSON", t.Context(), "status/v1/participant/participant-1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.Participant")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*Participant)
 		*result = *expectedParticipant
 	})
 

--- a/status/registration_alias.go
+++ b/status/registration_alias.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListRegistrationAliases(ctx context.Context, opts *ListOptions) (*RegistrationAliasListResponse, error) {
 	endpoint := "status/v1/registration_alias/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result RegistrationAliasListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetRegistrationAlias(ctx context.Context, id int) (*Registrati
 	endpoint := fmt.Sprintf("status/v1/registration_alias/%d/", id)
 
 	var result RegistrationAlias
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/registration_alias_test.go
+++ b/status/registration_alias_test.go
@@ -35,8 +35,8 @@ func TestService_ListRegistrationAliases(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/registration_alias/", mock.AnythingOfType("*status.RegistrationAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*RegistrationAliasListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/registration_alias/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.RegistrationAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*RegistrationAliasListResponse)
 		*result = *expectedResponse
 	})
 
@@ -81,10 +81,8 @@ func TestService_ListRegistrationAliases_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/registration_alias/"
-	}), mock.AnythingOfType("*status.RegistrationAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*RegistrationAliasListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/registration_alias/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.RegistrationAliasListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*RegistrationAliasListResponse)
 		*result = *expectedResponse
 	})
 
@@ -117,8 +115,8 @@ func TestService_GetRegistrationAlias(t *testing.T) {
 		Username:       "",
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/registration_alias/1/", mock.AnythingOfType("*status.RegistrationAlias")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*RegistrationAlias)
+	client.On("GetJSON", t.Context(), "status/v1/registration_alias/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.RegistrationAlias")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*RegistrationAlias)
 		*result = *expectedAlias
 	})
 

--- a/status/scheduling_operation.go
+++ b/status/scheduling_operation.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListSchedulingOperations(ctx context.Context, opts *ListOptions) (*SchedulingOperationListResponse, error) {
 	endpoint := "status/v1/scheduling_operation/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result SchedulingOperationListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetSchedulingOperation(ctx context.Context, id int) (*Scheduli
 	endpoint := fmt.Sprintf("status/v1/scheduling_operation/%d/", id)
 
 	var result SchedulingOperation
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/scheduling_operation_test.go
+++ b/status/scheduling_operation_test.go
@@ -36,8 +36,8 @@ func TestService_ListSchedulingOperations(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/scheduling_operation/", mock.AnythingOfType("*status.SchedulingOperationListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SchedulingOperationListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/scheduling_operation/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.SchedulingOperationListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SchedulingOperationListResponse)
 		*result = *expectedResponse
 	})
 
@@ -79,10 +79,8 @@ func TestService_ListSchedulingOperations_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/scheduling_operation/"
-	}), mock.AnythingOfType("*status.SchedulingOperationListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SchedulingOperationListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/scheduling_operation/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.SchedulingOperationListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SchedulingOperationListResponse)
 		*result = *expectedResponse
 	})
 
@@ -115,8 +113,8 @@ func TestService_GetSchedulingOperation(t *testing.T) {
 		TransactionUUID:  "uuid-3",
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/scheduling_operation/1/", mock.AnythingOfType("*status.SchedulingOperation")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SchedulingOperation)
+	client.On("GetJSON", t.Context(), "status/v1/scheduling_operation/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.SchedulingOperation")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SchedulingOperation)
 		*result = *expectedOperation
 	})
 

--- a/status/snapshot_request.go
+++ b/status/snapshot_request.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListSnapshotRequests(ctx context.Context, opts *ListOptions) (*SnapshotRequestListResponse, error) {
 	endpoint := "status/v1/snapshot_request/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result SnapshotRequestListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetSnapshotRequest(ctx context.Context, id int) (*SnapshotRequ
 	endpoint := fmt.Sprintf("status/v1/snapshot_request/%d/", id)
 
 	var result SnapshotRequest
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/snapshot_request_test.go
+++ b/status/snapshot_request_test.go
@@ -35,8 +35,8 @@ func TestService_ListSnapshotRequests(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/snapshot_request/", mock.AnythingOfType("*status.SnapshotRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SnapshotRequestListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/snapshot_request/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.SnapshotRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SnapshotRequestListResponse)
 		*result = *expectedResponse
 	})
 
@@ -78,10 +78,8 @@ func TestService_ListSnapshotRequests_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/snapshot_request/"
-	}), mock.AnythingOfType("*status.SnapshotRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SnapshotRequestListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/snapshot_request/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.SnapshotRequestListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SnapshotRequestListResponse)
 		*result = *expectedResponse
 	})
 
@@ -111,8 +109,8 @@ func TestService_GetSnapshotRequest(t *testing.T) {
 		UpdatedAt:   &util.InfinityTime{Time: updated},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/snapshot_request/1/", mock.AnythingOfType("*status.SnapshotRequest")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SnapshotRequest)
+	client.On("GetJSON", t.Context(), "status/v1/snapshot_request/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.SnapshotRequest")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SnapshotRequest)
 		*result = *expectedRequest
 	})
 

--- a/status/status.go
+++ b/status/status.go
@@ -10,6 +10,9 @@
 package status
 
 import (
+	"context"
+	"net/url"
+
 	"github.com/pexip/go-infinity-sdk/v38/interfaces"
 	"github.com/pexip/go-infinity-sdk/v38/options"
 )
@@ -28,3 +31,11 @@ func New(client interfaces.HTTPClient) *Service {
 
 // ListOptions contains options for listing resources
 type ListOptions = options.BaseListOptions
+
+func (s *Service) listEndpoint(ctx context.Context, endpoint string, opts *ListOptions, result interface{}) error {
+	var params url.Values
+	if opts != nil {
+		params = opts.ToURLValues()
+	}
+	return s.client.GetJSON(ctx, endpoint, &params, result)
+}

--- a/status/system_location.go
+++ b/status/system_location.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListSystemLocations(ctx context.Context, opts *ListOptions) (*SystemLocationListResponse, error) {
 	endpoint := "status/v1/system_location/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result SystemLocationListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetSystemLocation(ctx context.Context, id int) (*SystemLocatio
 	endpoint := fmt.Sprintf("status/v1/system_location/%d/", id)
 
 	var result SystemLocation
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/system_location_test.go
+++ b/status/system_location_test.go
@@ -48,8 +48,8 @@ func TestService_ListSystemLocations(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/system_location/", mock.AnythingOfType("*status.SystemLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SystemLocationListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/system_location/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.SystemLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SystemLocationListResponse)
 		*result = *expectedResponse
 	})
 
@@ -98,8 +98,8 @@ func TestService_GetSystemLocation(t *testing.T) {
 		MediaTokensUsed: 100,
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/system_location/1/", mock.AnythingOfType("*status.SystemLocation")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SystemLocation)
+	client.On("GetJSON", t.Context(), "status/v1/system_location/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.SystemLocation")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SystemLocation)
 		*result = *expectedLocation
 	})
 
@@ -148,10 +148,8 @@ func TestService_ListSystemLocations_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/system_location/"
-	}), mock.AnythingOfType("*status.SystemLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SystemLocationListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/system_location/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.SystemLocationListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SystemLocationListResponse)
 		*result = *expectedResponse
 	})
 

--- a/status/system_status.go
+++ b/status/system_status.go
@@ -15,6 +15,6 @@ func (s *Service) GetSystemStatus(ctx context.Context) (*SystemStatus, error) {
 	endpoint := "status/v1/system_status/"
 
 	var result SystemStatus
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/system_status_test.go
+++ b/status/system_status_test.go
@@ -30,8 +30,8 @@ func TestService_GetSystemStatus(t *testing.T) {
 		CPULoad:     25.5,
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/system_status/", mock.AnythingOfType("*status.SystemStatus")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*SystemStatus)
+	client.On("GetJSON", t.Context(), "status/v1/system_status/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.SystemStatus")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*SystemStatus)
 		*result = *expectedStatus
 	})
 

--- a/status/teamsnode.go
+++ b/status/teamsnode.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListTeamsNodes(ctx context.Context, opts *ListOptions) (*TeamsNodeListResponse, error) {
 	endpoint := "status/v1/teamsnode/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result TeamsNodeListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetTeamsNode(ctx context.Context, id int) (*TeamsNode, error) 
 	endpoint := fmt.Sprintf("status/v1/teamsnode/%d/", id)
 
 	var result TeamsNode
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/teamsnode_call.go
+++ b/status/teamsnode_call.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListTeamsNodeCalls(ctx context.Context, opts *ListOptions) (*TeamsNodeCallListResponse, error) {
 	endpoint := "status/v1/teamsnode_call/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result TeamsNodeCallListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetTeamsNodeCall(ctx context.Context, id string) (*TeamsNodeCa
 	endpoint := fmt.Sprintf("status/v1/teamsnode_call/%s/", id)
 
 	var result TeamsNodeCall
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/teamsnode_call_test.go
+++ b/status/teamsnode_call_test.go
@@ -34,8 +34,8 @@ func TestService_ListTeamsNodeCalls(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/teamsnode_call/", mock.AnythingOfType("*status.TeamsNodeCallListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*TeamsNodeCallListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/teamsnode_call/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.TeamsNodeCallListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*TeamsNodeCallListResponse)
 		*result = *expectedResponse
 	})
 
@@ -72,10 +72,8 @@ func TestService_ListTeamsNodeCalls_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/teamsnode_call/"
-	}), mock.AnythingOfType("*status.TeamsNodeCallListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*TeamsNodeCallListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/teamsnode_call/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.TeamsNodeCallListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*TeamsNodeCallListResponse)
 		*result = *expectedResponse
 	})
 
@@ -101,8 +99,8 @@ func TestService_GetTeamsNodeCall(t *testing.T) {
 		// Only fields present in the struct are set
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/teamsnode_call/call-456/", mock.AnythingOfType("*status.TeamsNodeCall")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*TeamsNodeCall)
+	client.On("GetJSON", t.Context(), "status/v1/teamsnode_call/call-456/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.TeamsNodeCall")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*TeamsNodeCall)
 		*result = *expectedCall
 	})
 

--- a/status/teamsnode_test.go
+++ b/status/teamsnode_test.go
@@ -42,8 +42,8 @@ func TestService_ListTeamsNodes(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/teamsnode/", mock.AnythingOfType("*status.TeamsNodeListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*TeamsNodeListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/teamsnode/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.TeamsNodeListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*TeamsNodeListResponse)
 		*result = *expectedResponse
 	})
 
@@ -80,8 +80,8 @@ func TestService_GetTeamsNode(t *testing.T) {
 		HeartbeatTime: &util.InfinityTime{Time: lastContact},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/teamsnode/1/", mock.AnythingOfType("*status.TeamsNode")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*TeamsNode)
+	client.On("GetJSON", t.Context(), "status/v1/teamsnode/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.TeamsNode")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*TeamsNode)
 		*result = *expectedNode
 	})
 
@@ -121,10 +121,8 @@ func TestService_ListTeamsNodes_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/teamsnode/"
-	}), mock.AnythingOfType("*status.TeamsNodeListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*TeamsNodeListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/teamsnode/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.TeamsNodeListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*TeamsNodeListResponse)
 		*result = *expectedResponse
 	})
 

--- a/status/worker_vm.go
+++ b/status/worker_vm.go
@@ -15,15 +15,8 @@ import (
 func (s *Service) ListWorkerVMs(ctx context.Context, opts *ListOptions) (*WorkerVMListResponse, error) {
 	endpoint := "status/v1/worker_vm/"
 
-	if opts != nil {
-		params := opts.ToURLValues()
-		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
-		}
-	}
-
 	var result WorkerVMListResponse
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.listEndpoint(ctx, endpoint, opts, &result)
 	return &result, err
 }
 
@@ -32,6 +25,6 @@ func (s *Service) GetWorkerVM(ctx context.Context, id int) (*WorkerVM, error) {
 	endpoint := fmt.Sprintf("status/v1/worker_vm/%d/", id)
 
 	var result WorkerVM
-	err := s.client.GetJSON(ctx, endpoint, &result)
+	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }

--- a/status/worker_vm_test.go
+++ b/status/worker_vm_test.go
@@ -38,8 +38,8 @@ func TestService_ListWorkerVMs(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/worker_vm/", mock.AnythingOfType("*status.WorkerVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*WorkerVMListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/worker_vm/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.WorkerVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*WorkerVMListResponse)
 		*result = *expectedResponse
 	})
 
@@ -74,10 +74,8 @@ func TestService_ListWorkerVMs_WithOptions(t *testing.T) {
 		},
 	}
 
-	client.On("GetJSON", t.Context(), mock.MatchedBy(func(endpoint string) bool {
-		return endpoint != "status/v1/worker_vm/"
-	}), mock.AnythingOfType("*status.WorkerVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*WorkerVMListResponse)
+	client.On("GetJSON", t.Context(), "status/v1/worker_vm/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.WorkerVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*WorkerVMListResponse)
 		*result = *expectedResponse
 	})
 
@@ -101,8 +99,8 @@ func TestService_GetWorkerVM(t *testing.T) {
 		UpgradeStatus:  "IDLE",
 	}
 
-	client.On("GetJSON", t.Context(), "status/v1/worker_vm/1/", mock.AnythingOfType("*status.WorkerVM")).Return(nil).Run(func(args mock.Arguments) {
-		result := args.Get(2).(*WorkerVM)
+	client.On("GetJSON", t.Context(), "status/v1/worker_vm/1/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*status.WorkerVM")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*WorkerVM)
 		*result = *expectedWorkerVM
 	})
 


### PR DESCRIPTION
# Description

This PR updates the `GetJSON` method across all services to accept query parameters as a separate argument, improving the separation of concerns between URL construction and parameter handling. The changes standardize how query parameters are passed to the HTTP client interface.

- Adds query parameters as a separate `*url.Values` argument to the `GetJSON` method signature
- Refactors all service methods to use the new parameter passing approach
- Updates test files to accommodate the new method signature