### PR TITLE
Update teams_proxy model and test

### DIFF
--- a/config/teams_proxy_model.go
+++ b/config/teams_proxy_model.go
@@ -29,25 +29,25 @@ type TeamsProxyCreateRequest struct {
 	Name                 string  `json:"name"`
 	Description          string  `json:"description,omitempty"`
 	Address              string  `json:"address"`
-	Port                 int     `json:"port"`
+	Port                 int     `json:"port,omitempty"`
 	AzureTenant          string  `json:"azure_tenant"`
 	EventhubID           *string `json:"eventhub_id,omitempty"`
-	MinNumberOfInstances int     `json:"min_number_of_instances"`
-	NotificationsEnabled bool    `json:"notifications_enabled"`
+	MinNumberOfInstances int     `json:"min_number_of_instances,omitempty"`
+	NotificationsEnabled bool    `json:"notifications_enabled,omitempty"`
 	NotificationsQueue   *string `json:"notifications_queue,omitempty"`
 }
 
 // TeamsProxyUpdateRequest represents a request to update a Teams proxy
 type TeamsProxyUpdateRequest struct {
 	Name                 string  `json:"name,omitempty"`
-	Description          string  `json:"description,omitempty"`
-	Address              string  `json:"address,omitempty"`
-	Port                 *int    `json:"port,omitempty"`
+	Description          string  `json:"description"`
+	Address              string  `json:"address"`
+	Port                 *int    `json:"port"`
 	AzureTenant          string  `json:"azure_tenant,omitempty"`
-	EventhubID           *string `json:"eventhub_id,omitempty"`
-	MinNumberOfInstances *int    `json:"min_number_of_instances,omitempty"`
-	NotificationsEnabled *bool   `json:"notifications_enabled,omitempty"`
-	NotificationsQueue   *string `json:"notifications_queue,omitempty"`
+	EventhubID           *string `json:"eventhub_id"`
+	MinNumberOfInstances *int    `json:"min_number_of_instances"`
+	NotificationsEnabled *bool   `json:"notifications_enabled"`
+	NotificationsQueue   *string `json:"notifications_queue"`
 }
 
 // TeamsProxyListResponse represents the response from listing Teams proxies

--- a/config/teams_proxy_model.go
+++ b/config/teams_proxy_model.go
@@ -10,27 +10,27 @@ import "github.com/pexip/go-infinity-sdk/v38/util"
 
 // TeamsProxy represents a Teams proxy configuration
 type TeamsProxy struct {
-	ID                   int                `json:"id,omitempty"`
+	ID                   int                `json:"id"`
 	Name                 string             `json:"name"`
 	Description          string             `json:"description,omitempty"`
 	Address              string             `json:"address"`
-	Port                 int                `json:"port"`
+	Port                 int                `json:"port,omitempty"`
 	AzureTenant          string             `json:"azure_tenant"`
 	EventhubID           *string            `json:"eventhub_id,omitempty"`
-	MinNumberOfInstances int                `json:"min_number_of_instances"`
-	NotificationsEnabled bool               `json:"notifications_enabled"`
+	MinNumberOfInstances int                `json:"min_number_of_instances,omitempty"`
+	NotificationsEnabled bool               `json:"notifications_enabled,omitempty"`
 	NotificationsQueue   *string            `json:"notifications_queue,omitempty"`
 	Updated              *util.InfinityTime `json:"updated,omitempty"`
-	ResourceURI          string             `json:"resource_uri,omitempty"`
+	ResourceURI          string             `json:"resource_uri"`
 }
 
 // TeamsProxyCreateRequest represents a request to create a Teams proxy
 type TeamsProxyCreateRequest struct {
-	Name                 string  `json:"name,omitempty"`
+	Name                 string  `json:"name"`
 	Description          string  `json:"description"`
 	Address              string  `json:"address"`
 	Port                 int     `json:"port"`
-	AzureTenant          string  `json:"azure_tenant,omitempty"`
+	AzureTenant          string  `json:"azure_tenant"`
 	EventhubID           *string `json:"eventhub_id"`
 	MinNumberOfInstances int     `json:"min_number_of_instances"`
 	NotificationsEnabled bool    `json:"notifications_enabled"`
@@ -39,11 +39,11 @@ type TeamsProxyCreateRequest struct {
 
 // TeamsProxyUpdateRequest represents a request to update a Teams proxy
 type TeamsProxyUpdateRequest struct {
-	Name                 string  `json:"name,omitempty"`
+	Name                 string  `json:"name"`
 	Description          string  `json:"description"`
 	Address              string  `json:"address"`
 	Port                 int     `json:"port"`
-	AzureTenant          string  `json:"azure_tenant,omitempty"`
+	AzureTenant          string  `json:"azure_tenant"`
 	EventhubID           *string `json:"eventhub_id"`
 	MinNumberOfInstances int     `json:"min_number_of_instances"`
 	NotificationsEnabled bool    `json:"notifications_enabled"`

--- a/config/teams_proxy_model.go
+++ b/config/teams_proxy_model.go
@@ -26,15 +26,15 @@ type TeamsProxy struct {
 
 // TeamsProxyCreateRequest represents a request to create a Teams proxy
 type TeamsProxyCreateRequest struct {
-	Name                 string  `json:"name"`
-	Description          string  `json:"description,omitempty"`
+	Name                 string  `json:"name,omitempty"`
+	Description          string  `json:"description"`
 	Address              string  `json:"address"`
-	Port                 int     `json:"port,omitempty"`
-	AzureTenant          string  `json:"azure_tenant"`
-	EventhubID           *string `json:"eventhub_id,omitempty"`
-	MinNumberOfInstances int     `json:"min_number_of_instances,omitempty"`
-	NotificationsEnabled bool    `json:"notifications_enabled,omitempty"`
-	NotificationsQueue   *string `json:"notifications_queue,omitempty"`
+	Port                 int     `json:"port"`
+	AzureTenant          string  `json:"azure_tenant,omitempty"`
+	EventhubID           *string `json:"eventhub_id"`
+	MinNumberOfInstances int     `json:"min_number_of_instances"`
+	NotificationsEnabled bool    `json:"notifications_enabled"`
+	NotificationsQueue   *string `json:"notifications_queue"`
 }
 
 // TeamsProxyUpdateRequest represents a request to update a Teams proxy
@@ -42,11 +42,11 @@ type TeamsProxyUpdateRequest struct {
 	Name                 string  `json:"name,omitempty"`
 	Description          string  `json:"description"`
 	Address              string  `json:"address"`
-	Port                 *int    `json:"port"`
+	Port                 int     `json:"port"`
 	AzureTenant          string  `json:"azure_tenant,omitempty"`
 	EventhubID           *string `json:"eventhub_id"`
-	MinNumberOfInstances *int    `json:"min_number_of_instances"`
-	NotificationsEnabled *bool   `json:"notifications_enabled"`
+	MinNumberOfInstances int     `json:"min_number_of_instances"`
+	NotificationsEnabled bool    `json:"notifications_enabled"`
 	NotificationsQueue   *string `json:"notifications_queue"`
 }
 

--- a/config/teams_proxy_model.go
+++ b/config/teams_proxy_model.go
@@ -12,15 +12,15 @@ import "github.com/pexip/go-infinity-sdk/v38/util"
 type TeamsProxy struct {
 	ID                   int                `json:"id"`
 	Name                 string             `json:"name"`
-	Description          string             `json:"description,omitempty"`
+	Description          string             `json:"description"`
 	Address              string             `json:"address"`
-	Port                 int                `json:"port,omitempty"`
+	Port                 int                `json:"port"`
 	AzureTenant          string             `json:"azure_tenant"`
-	EventhubID           *string            `json:"eventhub_id,omitempty"`
-	MinNumberOfInstances int                `json:"min_number_of_instances,omitempty"`
-	NotificationsEnabled bool               `json:"notifications_enabled,omitempty"`
-	NotificationsQueue   *string            `json:"notifications_queue,omitempty"`
-	Updated              *util.InfinityTime `json:"updated,omitempty"`
+	EventhubID           *string            `json:"eventhub_id"`
+	MinNumberOfInstances int                `json:"min_number_of_instances"`
+	NotificationsEnabled bool               `json:"notifications_enabled"`
+	NotificationsQueue   *string            `json:"notifications_queue"`
+	Updated              *util.InfinityTime `json:"updated"`
 	ResourceURI          string             `json:"resource_uri"`
 }
 

--- a/config/teams_proxy_test.go
+++ b/config/teams_proxy_test.go
@@ -163,15 +163,11 @@ func TestService_CreateTeamsProxy(t *testing.T) {
 func TestService_UpdateTeamsProxy(t *testing.T) {
 	client := interfaces.NewHTTPClientMock()
 
-	port := 8444
-	minInstances := 4
-	notificationsEnabled := false
-
 	updateRequest := &TeamsProxyUpdateRequest{
 		Description:          "Updated Teams proxy",
-		Port:                 &port,
-		MinNumberOfInstances: &minInstances,
-		NotificationsEnabled: &notificationsEnabled,
+		Port:                 8444,
+		MinNumberOfInstances: 4,
+		NotificationsEnabled: false,
 	}
 
 	updated := &util.InfinityTime{}


### PR DESCRIPTION
This pull request updates the `TeamsProxyCreateRequest` and `TeamsProxyUpdateRequest` structs to change the way required and optional fields are handled. The main change is making several fields required (removing `omitempty` and pointer types) and adjusting related test code accordingly.

This change was primarily made to allow min_num_instances to be set to 0.

Changes to TeamsProxy request models:

* Made `description`, `address`, and `port` required fields (removed `omitempty` and pointer types) in both `TeamsProxyCreateRequest` and `TeamsProxyUpdateRequest` structs. (`config/teams_proxy_model.go`, [config/teams_proxy_model.goL29-R50](diffhunk://#diff-7f4d465750050a8a31851f917b6c874587816e1895756d3f27e91c29eddf2bbfL29-R50))
* Changed `min_number_of_instances` and `notifications_enabled` to required fields (removed pointer types and `omitempty`) in `TeamsProxyUpdateRequest`. (`config/teams_proxy_model.go`, [config/teams_proxy_model.goL29-R50](diffhunk://#diff-7f4d465750050a8a31851f917b6c874587816e1895756d3f27e91c29eddf2bbfL29-R50))
* Updated `eventhub_id` and `notifications_queue` to be required (removed `omitempty`) in both structs. (`config/teams_proxy_model.go`, [config/teams_proxy_model.goL29-R50](diffhunk://#diff-7f4d465750050a8a31851f917b6c874587816e1895756d3f27e91c29eddf2bbfL29-R50))

Test updates:

* Updated the `TestService_UpdateTeamsProxy` test to use non-pointer, non-optional fields for `port`, `min_number_of_instances`, and `notifications_enabled`, matching the new struct requirements. (`config/teams_proxy_test.go`, [config/teams_proxy_test.goL166-R170](diffhunk://#diff-030470e8ce32edf18c51be8162f1f8609b1ba2d201cd4a3b4ba6a673d46281baL166-R170))# Description