### PR TITLE
Continue to update config resources schema to allow clearing of fields

### DIFF
--- a/config/automatic_participant_model.go
+++ b/config/automatic_participant_model.go
@@ -56,7 +56,7 @@ type AutomaticParticipantUpdateRequest struct {
 	DTMFSequence        string   `json:"dtmf_sequence,omitempty"`
 	KeepConferenceAlive string   `json:"keep_conference_alive,omitempty"`
 	Routing             string   `json:"routing,omitempty"`
-	SystemLocation      *string  `json:"system_location,omitempty"`
+	SystemLocation      *string  `json:"system_location"`
 	Streaming           *bool    `json:"streaming,omitempty"`
 	RemoteDisplayName   string   `json:"remote_display_name,omitempty"`
 	PresentationURL     string   `json:"presentation_url,omitempty"`

--- a/config/dns_server_model.go
+++ b/config/dns_server_model.go
@@ -23,7 +23,7 @@ type DNSServerCreateRequest struct {
 // DNSServerUpdateRequest represents a request to update a DNS server
 type DNSServerUpdateRequest struct {
 	Address     string `json:"address,omitempty"`
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 }
 
 // DNSServerListResponse represents the response from listing DNS servers

--- a/config/end_user_model.go
+++ b/config/end_user_model.go
@@ -48,19 +48,19 @@ type EndUserCreateRequest struct {
 // EndUserUpdateRequest represents a request to update an end user
 type EndUserUpdateRequest struct {
 	PrimaryEmailAddress string   `json:"primary_email_address,omitempty"`
-	FirstName           string   `json:"first_name,omitempty"`
-	LastName            string   `json:"last_name,omitempty"`
-	DisplayName         string   `json:"display_name,omitempty"`
-	TelephoneNumber     string   `json:"telephone_number,omitempty"`
-	MobileNumber        string   `json:"mobile_number,omitempty"`
-	Title               string   `json:"title,omitempty"`
-	Department          string   `json:"department,omitempty"`
-	AvatarURL           string   `json:"avatar_url,omitempty"`
+	FirstName           string   `json:"first_name"`
+	LastName            string   `json:"last_name"`
+	DisplayName         string   `json:"display_name"`
+	TelephoneNumber     string   `json:"telephone_number"`
+	MobileNumber        string   `json:"mobile_number"`
+	Title               string   `json:"title"`
+	Department          string   `json:"department"`
+	AvatarURL           string   `json:"avatar_url"`
 	UserGroups          []string `json:"user_groups,omitempty"`
 	UserOID             *string  `json:"user_oid,omitempty"`
 	ExchangeUserID      *string  `json:"exchange_user_id,omitempty"`
 	MSExchangeGUID      *string  `json:"ms_exchange_guid,omitempty"`
-	SyncTag             string   `json:"sync_tag,omitempty"`
+	SyncTag             string   `json:"sync_tag"`
 }
 
 // EndUserListResponse represents the response from listing end users

--- a/config/h323_gatekeeper_model.go
+++ b/config/h323_gatekeeper_model.go
@@ -27,7 +27,7 @@ type H323GatekeeperCreateRequest struct {
 // H323GatekeeperUpdateRequest represents a request to update an H.323 gatekeeper
 type H323GatekeeperUpdateRequest struct {
 	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 	Address     string `json:"address,omitempty"`
 	Port        *int   `json:"port,omitempty"`
 }

--- a/config/http_proxy_model.go
+++ b/config/http_proxy_model.go
@@ -33,8 +33,8 @@ type HTTPProxyUpdateRequest struct {
 	Name     string `json:"name,omitempty"`
 	Address  string `json:"address,omitempty"`
 	Port     *int   `json:"port,omitempty"`
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
+	Username string `json:"username"`
+	Password string `json:"password"`
 	Protocol string `json:"protocol,omitempty"`
 }
 

--- a/config/identity_provider_attribute_model.go
+++ b/config/identity_provider_attribute_model.go
@@ -23,7 +23,7 @@ type IdentityProviderAttributeCreateRequest struct {
 // IdentityProviderAttributeUpdateRequest represents a request to update an identity provider attribute
 type IdentityProviderAttributeUpdateRequest struct {
 	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 }
 
 // IdentityProviderAttributeListResponse represents the response from listing identity provider attributes

--- a/config/identity_provider_group_model.go
+++ b/config/identity_provider_group_model.go
@@ -25,7 +25,7 @@ type IdentityProviderGroupCreateRequest struct {
 // IdentityProviderGroupUpdateRequest represents a request to update an identity provider group
 type IdentityProviderGroupUpdateRequest struct {
 	Name             string   `json:"name,omitempty"`
-	Description      string   `json:"description,omitempty"`
+	Description      string   `json:"description"`
 	IdentityProvider []string `json:"identity_provider,omitempty"`
 }
 

--- a/config/ivr_theme_model.go
+++ b/config/ivr_theme_model.go
@@ -33,7 +33,7 @@ type IVRThemeCreateRequest struct {
 
 // IVRThemeUpdateRequest represents a request to update an IVR theme
 type IVRThemeUpdateRequest struct {
-	Name           string   `json:"name,omitempty"`
+	Name           string   `json:"name"`
 	UUID           string   `json:"uuid,omitempty"`
 	Conference     []string `json:"conference,omitempty"`
 	CustomLayouts  string   `json:"custom_layouts,omitempty"`

--- a/config/log_level_model.go
+++ b/config/log_level_model.go
@@ -22,8 +22,8 @@ type LogLevelCreateRequest struct {
 
 // LogLevelUpdateRequest represents a request to update a log level
 type LogLevelUpdateRequest struct {
-	Name  string `json:"name,omitempty"`
-	Level string `json:"level,omitempty"`
+	Name  string `json:"name"`
+	Level string `json:"level"`
 }
 
 // LogLevelListResponse represents the response from listing log levels

--- a/config/media_library_entry_model.go
+++ b/config/media_library_entry_model.go
@@ -28,7 +28,7 @@ type MediaLibraryEntryCreateRequest struct {
 
 // MediaLibraryEntryUpdateRequest represents a request to update a media library entry
 type MediaLibraryEntryUpdateRequest struct {
-	Name        string `json:"name,omitempty"`
+	Name        string `json:"name"`
 	Description string `json:"description"`
 	UUID        string `json:"uuid,omitempty"`
 }

--- a/config/mssip_proxy_model.go
+++ b/config/mssip_proxy_model.go
@@ -29,7 +29,7 @@ type MSSIPProxyCreateRequest struct {
 // MSSIPProxyUpdateRequest represents a request to update an MS-SIP proxy
 type MSSIPProxyUpdateRequest struct {
 	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 	Address     string `json:"address,omitempty"`
 	Port        *int   `json:"port,omitempty"`
 	Transport   string `json:"transport,omitempty"`

--- a/config/ntp_server_model.go
+++ b/config/ntp_server_model.go
@@ -27,7 +27,7 @@ type NTPServerCreateRequest struct {
 // NTPServerUpdateRequest represents a request to update an NTP server
 type NTPServerUpdateRequest struct {
 	Address     string `json:"address,omitempty"`
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 	Key         string `json:"key,omitempty"`
 	KeyID       *int   `json:"key_id,omitempty"`
 }

--- a/config/policy_server_model.go
+++ b/config/policy_server_model.go
@@ -55,10 +55,10 @@ type PolicyServerCreateRequest struct {
 // PolicyServerUpdateRequest represents a request to update a policy server
 type PolicyServerUpdateRequest struct {
 	Name                                string `json:"name,omitempty"`
-	Description                         string `json:"description,omitempty"`
-	URL                                 string `json:"url,omitempty"`
-	Username                            string `json:"username,omitempty"`
-	Password                            string `json:"password,omitempty"`
+	Description                         string `json:"description"`
+	URL                                 string `json:"url"`
+	Username                            string `json:"username"`
+	Password                            string `json:"password"`
 	EnableServiceLookup                 *bool  `json:"enable_service_lookup,omitempty"`
 	EnableParticipantLookup             *bool  `json:"enable_participant_lookup,omitempty"`
 	EnableRegistrationLookup            *bool  `json:"enable_registration_lookup,omitempty"`
@@ -68,9 +68,9 @@ type PolicyServerUpdateRequest struct {
 	EnableInternalServicePolicy         *bool  `json:"enable_internal_service_policy,omitempty"`
 	EnableInternalParticipantPolicy     *bool  `json:"enable_internal_participant_policy,omitempty"`
 	EnableInternalMediaLocationPolicy   *bool  `json:"enable_internal_media_location_policy,omitempty"`
-	InternalServicePolicyTemplate       string `json:"internal_service_policy_template,omitempty"`
-	InternalParticipantPolicyTemplate   string `json:"internal_participant_policy_template,omitempty"`
-	InternalMediaLocationPolicyTemplate string `json:"internal_media_location_policy_template,omitempty"`
+	InternalServicePolicyTemplate       string `json:"internal_service_policy_template"`
+	InternalParticipantPolicyTemplate   string `json:"internal_participant_policy_template"`
+	InternalMediaLocationPolicyTemplate string `json:"internal_media_location_policy_template"`
 	PreferLocalAvatarConfiguration      *bool  `json:"prefer_local_avatar_configuration,omitempty"`
 }
 

--- a/config/role_model.go
+++ b/config/role_model.go
@@ -23,7 +23,7 @@ type RoleCreateRequest struct {
 // RoleUpdateRequest represents a request to update a role
 type RoleUpdateRequest struct {
 	Name        string   `json:"name,omitempty"`
-	Permissions []string `json:"permissions,omitempty"`
+	Permissions []string `json:"permissions"`
 }
 
 // RoleListResponse represents the response from listing roles

--- a/config/sip_credential_model.go
+++ b/config/sip_credential_model.go
@@ -26,7 +26,7 @@ type SIPCredentialCreateRequest struct {
 type SIPCredentialUpdateRequest struct {
 	Realm    string `json:"realm,omitempty"`
 	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
+	Password string `json:"password"`
 }
 
 // SIPCredentialListResponse represents the response from listing SIP credentials

--- a/config/snmp_network_management_system_model.go
+++ b/config/snmp_network_management_system_model.go
@@ -29,10 +29,10 @@ type SnmpNetworkManagementSystemCreateRequest struct {
 // SnmpNetworkManagementSystemUpdateRequest represents a request to update an SNMP network management system
 type SnmpNetworkManagementSystemUpdateRequest struct {
 	Name              string `json:"name,omitempty"`
-	Description       string `json:"description,omitempty"`
+	Description       string `json:"description"`
 	Address           string `json:"address,omitempty"`
 	Port              *int   `json:"port,omitempty"`
-	SnmpTrapCommunity string `json:"snmp_trap_community,omitempty"`
+	SnmpTrapCommunity string `json:"snmp_trap_community"`
 }
 
 // SnmpNetworkManagementSystemListResponse represents the response from listing SNMP network management systems

--- a/config/ssh_authorized_key_model.go
+++ b/config/ssh_authorized_key_model.go
@@ -18,7 +18,7 @@ type SSHAuthorizedKey struct {
 
 // SSHAuthorizedKeyCreateRequest represents a request to create an SSH authorized key
 type SSHAuthorizedKeyCreateRequest struct {
-	Keytype string   `json:"keytype"`
+	Keytype string   `json:"keytype,omitempty"`
 	Key     string   `json:"key"`
 	Comment string   `json:"comment,omitempty"`
 	Nodes   []string `json:"nodes,omitempty"`

--- a/config/stun_server_model.go
+++ b/config/stun_server_model.go
@@ -19,7 +19,7 @@ type STUNServer struct {
 // STUNServerCreateRequest represents a request to create a STUN server
 type STUNServerCreateRequest struct {
 	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 	Address     string `json:"address"`
 	Port        int    `json:"port"`
 }
@@ -27,7 +27,7 @@ type STUNServerCreateRequest struct {
 // STUNServerUpdateRequest represents a request to update a STUN server
 type STUNServerUpdateRequest struct {
 	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 	Address     string `json:"address,omitempty"`
 	Port        *int   `json:"port,omitempty"`
 }

--- a/config/syslog_server_model.go
+++ b/config/syslog_server_model.go
@@ -33,7 +33,7 @@ type SyslogServerCreateRequest struct {
 // SyslogServerUpdateRequest represents a request to update a syslog server
 type SyslogServerUpdateRequest struct {
 	Address     string `json:"address,omitempty"`
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 	Port        int    `json:"port,omitempty"`
 	Transport   string `json:"transport,omitempty"`
 	AuditLog    *bool  `json:"audit_log,omitempty"`

--- a/config/system_tuneable_model.go
+++ b/config/system_tuneable_model.go
@@ -22,8 +22,8 @@ type SystemTuneableCreateRequest struct {
 
 // SystemTuneableUpdateRequest represents a request to update a system tuneable
 type SystemTuneableUpdateRequest struct {
-	Name    string `json:"name,omitempty"`
-	Setting string `json:"setting,omitempty"`
+	Name    string `json:"name"`
+	Setting string `json:"setting"`
 }
 
 // SystemTuneableListResponse represents the response from listing system tuneables

--- a/config/turn_server_model.go
+++ b/config/turn_server_model.go
@@ -37,12 +37,12 @@ type TURNServerCreateRequest struct {
 // TURNServerUpdateRequest represents a request to update a TURN server
 type TURNServerUpdateRequest struct {
 	Name          string `json:"name,omitempty"`
-	Description   string `json:"description,omitempty"`
+	Description   string `json:"description"`
 	Address       string `json:"address,omitempty"`
 	Port          *int   `json:"port,omitempty"`
-	Username      string `json:"username,omitempty"`
-	Password      string `json:"password,omitempty"`
-	SecretKey     string `json:"secret_key,omitempty"`
+	Username      string `json:"username"`
+	Password      string `json:"password"`
+	SecretKey     string `json:"secret_key"`
 	ServerType    string `json:"server_type,omitempty"`
 	TransportType string `json:"transport_type,omitempty"`
 }

--- a/config/user_group_entity_mapping_model.go
+++ b/config/user_group_entity_mapping_model.go
@@ -24,7 +24,7 @@ type UserGroupEntityMappingCreateRequest struct {
 
 // UserGroupEntityMappingUpdateRequest represents a request to update a user group entity mapping
 type UserGroupEntityMappingUpdateRequest struct {
-	Description       string `json:"description,omitempty"`
+	Description       string `json:"description"`
 	EntityResourceURI string `json:"entity_resource_uri,omitempty"`
 	UserGroup         string `json:"user_group,omitempty"`
 }

--- a/config/user_group_model.go
+++ b/config/user_group_model.go
@@ -27,7 +27,7 @@ type UserGroupCreateRequest struct {
 // UserGroupUpdateRequest represents a request to update a user group
 type UserGroupUpdateRequest struct {
 	Name                    string   `json:"name,omitempty"`
-	Description             string   `json:"description,omitempty"`
+	Description             string   `json:"description"`
 	Users                   []string `json:"users,omitempty"`
 	UserGroupEntityMappings []string `json:"user_group_entity_mappings,omitempty"`
 }

--- a/config/webapp_alias_model.go
+++ b/config/webapp_alias_model.go
@@ -31,7 +31,7 @@ type WebappAliasCreateRequest struct {
 // WebappAliasUpdateRequest represents a request to update a web app alias
 type WebappAliasUpdateRequest struct {
 	Slug        string  `json:"slug,omitempty"`
-	Description string  `json:"description,omitempty"`
+	Description string  `json:"description"`
 	WebappType  string  `json:"webapp_type,omitempty"`
 	IsEnabled   *bool   `json:"is_enabled,omitempty"`
 	Bundle      *string `json:"bundle,omitempty"`

--- a/config/webapp_branding_model.go
+++ b/config/webapp_branding_model.go
@@ -28,8 +28,8 @@ type WebappBrandingCreateRequest struct {
 
 // WebappBrandingUpdateRequest represents a request to update a webapp branding
 type WebappBrandingUpdateRequest struct {
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
 	UUID        string `json:"uuid,omitempty"`
 	WebappType  string `json:"webapp_type,omitempty"`
 }


### PR DESCRIPTION
# Description

This PR updates the schema of some config resources to allow clearing certain fields by removing `omitempty`. There is one field for `ssh_authorized_key` where it is added, as this field does not need to be cleared. This is the pattern that is being used to support the Infinity Terraform provider.

## How Has This Been Tested?

Unit and integration tests.