### PR TITLE
fix ivr theme

### DIFF
--- a/config/ivr_theme.go
+++ b/config/ivr_theme.go
@@ -47,9 +47,12 @@ func (s *Service) CreateIVRTheme(ctx context.Context, req *IVRThemeCreateRequest
 	// Create form fields from request
 	fields := map[string]string{
 		"name":            req.Name,
-		"uuid":            req.UUID,
 		"custom_layouts":  req.CustomLayouts,
 		"pinning_configs": req.PinningConfigs,
+	}
+
+	if req.UUID != "" {
+		fields["uuid"] = req.UUID
 	}
 
 	// Convert Conference slice to JSON string if not empty
@@ -61,23 +64,7 @@ func (s *Service) CreateIVRTheme(ctx context.Context, req *IVRThemeCreateRequest
 		fields["conference"] = string(conferenceJSON)
 	}
 
-	var err error
-	var resp *types.PostResponse
-	if resp, err = s.client.PostMultipartFormWithFieldsAndResponse(ctx, endpoint, fields, "", "", nil, nil); err != nil {
-		return resp, err
-	}
-
-	// We do this as a workaround since the API does not handle uploading the file in the POST request. This is probably a bug in the Infinity API.
-	id, err := resp.ResourceID()
-	if err != nil {
-		return resp, err
-	}
-	var result IVRTheme
-	_, err = s.client.PatchMultipartFormWithFieldsAndResponse(ctx, fmt.Sprintf("%s%d/", endpoint, id), nil, "package", filename, file, &result)
-	if err != nil {
-		return nil, err
-	}
-	return resp, err
+	return s.client.PostMultipartFormWithFieldsAndResponse(ctx, endpoint, fields, "package", filename, file, nil)
 }
 
 // UpdateIVRTheme updates an existing IVR theme
@@ -87,9 +74,12 @@ func (s *Service) UpdateIVRTheme(ctx context.Context, id int, req *IVRThemeUpdat
 	// Create form fields from request
 	fields := map[string]string{
 		"name":            req.Name,
-		"uuid":            req.UUID,
 		"custom_layouts":  req.CustomLayouts,
 		"pinning_configs": req.PinningConfigs,
+	}
+
+	if req.UUID != "" {
+		fields["uuid"] = req.UUID
 	}
 
 	// Convert Conference slice to JSON string if not empty

--- a/config/ivr_theme_test.go
+++ b/config/ivr_theme_test.go
@@ -175,28 +175,8 @@ func TestService_CreateIVRTheme(t *testing.T) {
 		ResourceURI: "/api/admin/configuration/v1/ivr_theme/123/",
 	}
 
-	lastUpdated := util.InfinityTime{Time: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)}
-	expectedTheme := &IVRTheme{
-		ID:   123,
-		Name: "new-theme",
-		UUID: "new12345-1234-5678-9abc-123456789012",
-		Conference: []string{
-			"/api/admin/configuration/v1/conference/3/",
-		},
-		CustomLayouts:  `{"newLayout": "newConfig"}`,
-		PinningConfigs: `{"newPin": "newPinConfig"}`,
-		LastUpdated:    lastUpdated,
-		ResourceURI:    "/api/admin/configuration/v1/ivr_theme/123/",
-	}
-
-	// First call: POST multipart form without file (workaround for API limitation)
-	client.On("PostMultipartFormWithFieldsAndResponse", t.Context(), "configuration/v1/ivr_theme/", expectedFields, "", "", nil, nil).Return(expectedResponse, nil)
-
-	// Second call: PATCH to upload the file
-	client.On("PatchMultipartFormWithFieldsAndResponse", t.Context(), "configuration/v1/ivr_theme/123/", mock.Anything, "package", "new_package.tar.gz", packageContent, mock.AnythingOfType("*config.IVRTheme")).Return(nil, nil).Run(func(args mock.Arguments) {
-		result := args.Get(6).(*IVRTheme)
-		*result = *expectedTheme
-	})
+	// Single call: POST multipart form with file included
+	client.On("PostMultipartFormWithFieldsAndResponse", t.Context(), "configuration/v1/ivr_theme/", expectedFields, "package", "new_package.tar.gz", packageContent, nil).Return(expectedResponse, nil)
 
 	service := New(client)
 	result, err := service.CreateIVRTheme(t.Context(), createRequest, "new_package.tar.gz", packageContent)
@@ -220,10 +200,9 @@ func TestService_UpdateIVRTheme(t *testing.T) {
 	}
 
 	expectedFields := map[string]string{
-		"name":            "updated-theme",
-		"uuid":            "",
-		"conference":      `["/api/admin/configuration/v1/conference/1/","/api/admin/configuration/v1/conference/4/"]`,
-		"custom_layouts":  `{"updatedLayout": "updatedConfig"}`,
+		"name":           "updated-theme",
+		"conference":     `["/api/admin/configuration/v1/conference/1/","/api/admin/configuration/v1/conference/4/"]`,
+		"custom_layouts": `{"updatedLayout": "updatedConfig"}`,
 		"pinning_configs": "",
 	}
 

--- a/config/ivr_theme_test.go
+++ b/config/ivr_theme_test.go
@@ -200,9 +200,9 @@ func TestService_UpdateIVRTheme(t *testing.T) {
 	}
 
 	expectedFields := map[string]string{
-		"name":           "updated-theme",
-		"conference":     `["/api/admin/configuration/v1/conference/1/","/api/admin/configuration/v1/conference/4/"]`,
-		"custom_layouts": `{"updatedLayout": "updatedConfig"}`,
+		"name":            "updated-theme",
+		"conference":      `["/api/admin/configuration/v1/conference/1/","/api/admin/configuration/v1/conference/4/"]`,
+		"custom_layouts":  `{"updatedLayout": "updatedConfig"}`,
 		"pinning_configs": "",
 	}
 

--- a/config/mjx_exchange_deployment_model.go
+++ b/config/mjx_exchange_deployment_model.go
@@ -13,28 +13,28 @@ type MjxExchangeAutodiscoverURLReference struct {
 
 // MjxExchangeDeployment represents a MJX Exchange deployment configuration
 type MjxExchangeDeployment struct {
-	ID                             int       `json:"id,omitempty"`
-	Name                           string    `json:"name"`
-	Description                    string    `json:"description,omitempty"`
-	ServiceAccountUsername         string    `json:"service_account_username"`
-	ServiceAccountPassword         string    `json:"service_account_password,omitempty"`
-	AuthenticationMethod           string    `json:"authentication_method"`
-	EWSURL                         string    `json:"ews_url,omitempty"`
-	DisableProxy                   bool      `json:"disable_proxy"`
-	FindItemsRequestQuota          int       `json:"find_items_request_quota"`
-	KerberosRealm                  string    `json:"kerberos_realm,omitempty"`
-	KerberosKDC                    string    `json:"kerberos_kdc,omitempty"`
-	KerberosExchangeSPN            string    `json:"kerberos_exchange_spn,omitempty"`
-	KerberosAuthEveryRequest       bool      `json:"kerberos_auth_every_request"`
-	KerberosEnableTLS              bool      `json:"kerberos_enable_tls"`
-	KerberosKDCHTTPSProxy          string    `json:"kerberos_kdc_https_proxy,omitempty"`
-	KerberosVerifyTLSUsingCustomCA bool      `json:"kerberos_verify_tls_using_custom_ca"`
-	OAuthClientID                  *string   `json:"oauth_client_id,omitempty"`
-	OAuthAuthEndpoint              string    `json:"oauth_auth_endpoint,omitempty"`
-	OAuthTokenEndpoint             string    `json:"oauth_token_endpoint,omitempty"`
-	OAuthRedirectURI               string    `json:"oauth_redirect_uri,omitempty"`
-	OAuthRefreshToken              string    `json:"oauth_refresh_token,omitempty"`
-	OAuthState                     *string   `json:"oauth_state,omitempty"`
+	ID                             int                                    `json:"id,omitempty"`
+	Name                           string                                 `json:"name"`
+	Description                    string                                 `json:"description,omitempty"`
+	ServiceAccountUsername         string                                 `json:"service_account_username"`
+	ServiceAccountPassword         string                                 `json:"service_account_password,omitempty"`
+	AuthenticationMethod           string                                 `json:"authentication_method"`
+	EWSURL                         string                                 `json:"ews_url,omitempty"`
+	DisableProxy                   bool                                   `json:"disable_proxy"`
+	FindItemsRequestQuota          int                                    `json:"find_items_request_quota"`
+	KerberosRealm                  string                                 `json:"kerberos_realm,omitempty"`
+	KerberosKDC                    string                                 `json:"kerberos_kdc,omitempty"`
+	KerberosExchangeSPN            string                                 `json:"kerberos_exchange_spn,omitempty"`
+	KerberosAuthEveryRequest       bool                                   `json:"kerberos_auth_every_request"`
+	KerberosEnableTLS              bool                                   `json:"kerberos_enable_tls"`
+	KerberosKDCHTTPSProxy          string                                 `json:"kerberos_kdc_https_proxy,omitempty"`
+	KerberosVerifyTLSUsingCustomCA bool                                   `json:"kerberos_verify_tls_using_custom_ca"`
+	OAuthClientID                  *string                                `json:"oauth_client_id,omitempty"`
+	OAuthAuthEndpoint              string                                 `json:"oauth_auth_endpoint,omitempty"`
+	OAuthTokenEndpoint             string                                 `json:"oauth_token_endpoint,omitempty"`
+	OAuthRedirectURI               string                                 `json:"oauth_redirect_uri,omitempty"`
+	OAuthRefreshToken              string                                 `json:"oauth_refresh_token,omitempty"`
+	OAuthState                     *string                                `json:"oauth_state,omitempty"`
 	AutodiscoverURLs               *[]MjxExchangeAutodiscoverURLReference `json:"autodiscover_urls,omitempty"`
 	MjxIntegrations                *[]string                              `json:"mjx_integrations,omitempty"`
 	ResourceURI                    string                                 `json:"resource_uri,omitempty"`

--- a/config/mjx_integration_model.go
+++ b/config/mjx_integration_model.go
@@ -13,34 +13,34 @@ type MjxIntegrationResourceReference struct {
 
 // MjxIntegration represents a MJX integration configuration
 type MjxIntegration struct {
-	ID                          int                                `json:"id,omitempty"`
-	Name                        string                             `json:"name"`
-	Description                 string                             `json:"description,omitempty"`
-	DisplayUpcomingMeetings     int                                `json:"display_upcoming_meetings"`
-	EnableNonVideoMeetings      bool                               `json:"enable_non_video_meetings"`
-	EnablePrivateMeetings       bool                               `json:"enable_private_meetings"`
-	EndBuffer                   int                                `json:"end_buffer"`
-	StartBuffer                 int                                `json:"start_buffer"`
-	EPUsername                  string                             `json:"ep_username,omitempty"`
-	EPPassword                  string                             `json:"ep_password,omitempty"`
-	EPUseHTTPS                  bool                               `json:"ep_use_https"`
-	EPVerifyCertificate         bool                               `json:"ep_verify_certificate"`
-	ExchangeDeployment          *MjxIntegrationResourceReference   `json:"exchange_deployment,omitempty"`
-	GoogleDeployment            *MjxIntegrationResourceReference   `json:"google_deployment,omitempty"`
-	GraphDeployment             *MjxIntegrationResourceReference   `json:"graph_deployment,omitempty"`
-	ProcessAliasPrivateMeetings bool                               `json:"process_alias_private_meetings"`
-	ReplaceEmptySubject         bool                               `json:"replace_empty_subject"`
-	ReplaceSubjectType          string                             `json:"replace_subject_type"`
-	ReplaceSubjectTemplate      string                             `json:"replace_subject_template,omitempty"`
-	UseWebex                    bool                               `json:"use_webex"`
-	WebexAPIDomain              string                             `json:"webex_api_domain,omitempty"`
-	WebexClientID               *string                            `json:"webex_client_id,omitempty"`
-	WebexClientSecret           *string                            `json:"webex_client_secret,omitempty"`
-	WebexOAuthState             *string                            `json:"webex_oauth_state,omitempty"`
-	WebexRedirectURI            *string                            `json:"webex_redirect_uri,omitempty"`
-	WebexRefreshToken           *string                            `json:"webex_refresh_token,omitempty"`
-	EndpointGroups              []MjxIntegrationResourceReference  `json:"endpoint_groups,omitempty"`
-	ResourceURI                 string                             `json:"resource_uri,omitempty"`
+	ID                          int                               `json:"id,omitempty"`
+	Name                        string                            `json:"name"`
+	Description                 string                            `json:"description,omitempty"`
+	DisplayUpcomingMeetings     int                               `json:"display_upcoming_meetings"`
+	EnableNonVideoMeetings      bool                              `json:"enable_non_video_meetings"`
+	EnablePrivateMeetings       bool                              `json:"enable_private_meetings"`
+	EndBuffer                   int                               `json:"end_buffer"`
+	StartBuffer                 int                               `json:"start_buffer"`
+	EPUsername                  string                            `json:"ep_username,omitempty"`
+	EPPassword                  string                            `json:"ep_password,omitempty"`
+	EPUseHTTPS                  bool                              `json:"ep_use_https"`
+	EPVerifyCertificate         bool                              `json:"ep_verify_certificate"`
+	ExchangeDeployment          *MjxIntegrationResourceReference  `json:"exchange_deployment,omitempty"`
+	GoogleDeployment            *MjxIntegrationResourceReference  `json:"google_deployment,omitempty"`
+	GraphDeployment             *MjxIntegrationResourceReference  `json:"graph_deployment,omitempty"`
+	ProcessAliasPrivateMeetings bool                              `json:"process_alias_private_meetings"`
+	ReplaceEmptySubject         bool                              `json:"replace_empty_subject"`
+	ReplaceSubjectType          string                            `json:"replace_subject_type"`
+	ReplaceSubjectTemplate      string                            `json:"replace_subject_template,omitempty"`
+	UseWebex                    bool                              `json:"use_webex"`
+	WebexAPIDomain              string                            `json:"webex_api_domain,omitempty"`
+	WebexClientID               *string                           `json:"webex_client_id,omitempty"`
+	WebexClientSecret           *string                           `json:"webex_client_secret,omitempty"`
+	WebexOAuthState             *string                           `json:"webex_oauth_state,omitempty"`
+	WebexRedirectURI            *string                           `json:"webex_redirect_uri,omitempty"`
+	WebexRefreshToken           *string                           `json:"webex_refresh_token,omitempty"`
+	EndpointGroups              []MjxIntegrationResourceReference `json:"endpoint_groups,omitempty"`
+	ResourceURI                 string                            `json:"resource_uri,omitempty"`
 }
 
 // MjxIntegrationCreateRequest represents a request to create a MJX integration


### PR DESCRIPTION
This pull request simplifies and improves the logic for creating and updating IVR themes by streamlining how form fields are handled and how files are uploaded. The main focus is on removing unnecessary workaround code, making the API usage more straightforward, and ensuring that optional fields are only included when necessary. The related tests have also been updated to reflect these changes.

**Improvements to IVR Theme creation and update logic:**

- Only include the `uuid` field in form data if it is non-empty, reducing unnecessary data sent to the API. [[1]](diffhunk://#diff-e1e0a3fcf0bb8db2eb5b0db26c39a69d360e11911cade6c5dfb19430ad5c42c5L50-R57) [[2]](diffhunk://#diff-e1e0a3fcf0bb8db2eb5b0db26c39a69d360e11911cade6c5dfb19430ad5c42c5L90-R84)
- Simplified the `CreateIVRTheme` method to perform the file upload in a single POST request instead of a two-step POST-then-PATCH workaround, as the API now supports this directly.

**Updates to tests:**

- Updated the `TestService_CreateIVRTheme` test to expect a single call to `PostMultipartFormWithFieldsAndResponse` with the file included, instead of the previous two-step POST and PATCH sequence.
- Adjusted the expected fields in `TestService_UpdateIVRTheme` to omit the `uuid` field when it is empty, matching the new logic.