### PR TITLE
Update UpdateAutobackup method to use PatchJSON and modify model

### DIFF
--- a/config/autobackup.go
+++ b/config/autobackup.go
@@ -24,6 +24,6 @@ func (s *Service) UpdateAutobackup(ctx context.Context, req *AutobackupUpdateReq
 	endpoint := "configuration/v1/autobackup/1/"
 
 	var result Autobackup
-	err := s.client.PutJSON(ctx, endpoint, req, &result)
+	err := s.client.PatchJSON(ctx, endpoint, req, &result)
 	return &result, err
 }

--- a/config/autobackup.go
+++ b/config/autobackup.go
@@ -24,6 +24,6 @@ func (s *Service) UpdateAutobackup(ctx context.Context, req *AutobackupUpdateReq
 	endpoint := "configuration/v1/autobackup/1/"
 
 	var result Autobackup
-	err := s.client.PatchJSON(ctx, endpoint, req, &result)
+	err := s.client.PutJSON(ctx, endpoint, req, &result)
 	return &result, err
 }

--- a/config/autobackup_model.go
+++ b/config/autobackup_model.go
@@ -23,9 +23,9 @@ type Autobackup struct {
 type AutobackupUpdateRequest struct {
 	AutobackupEnabled        *bool  `json:"autobackup_enabled,omitempty"`
 	AutobackupInterval       *int   `json:"autobackup_interval,omitempty"`
-	AutobackupPassphrase     string `json:"autobackup_passphrase,omitempty"`
+	AutobackupPassphrase     string `json:"autobackup_passphrase"`
 	AutobackupStartHour      *int   `json:"autobackup_start_hour,omitempty"`
-	AutobackupUploadURL      string `json:"autobackup_upload_url,omitempty"`
-	AutobackupUploadUsername string `json:"autobackup_upload_username,omitempty"`
-	AutobackupUploadPassword string `json:"autobackup_upload_password,omitempty"`
+	AutobackupUploadURL      string `json:"autobackup_upload_url"`
+	AutobackupUploadUsername string `json:"autobackup_upload_username"`
+	AutobackupUploadPassword string `json:"autobackup_upload_password"`
 }


### PR DESCRIPTION
This pull request updates how autobackup configuration updates are handled and changes the serialization of certain fields in the `AutobackupUpdateRequest` struct. The main changes improve the API semantics and ensure that sensitive fields are always included in update requests.

API method update:

* Changed the HTTP method for updating autobackup configuration from `PUT` to `PATCH` to better reflect partial updates in `config/autobackup.go`. PUT is not a supported method by the API.

Autobackup update request struct changes:

* Made the fields `AutobackupPassphrase`, `AutobackupUploadURL`, `AutobackupUploadUsername`, and `AutobackupUploadPassword` always included in the JSON payload (removed `omitempty`), ensuring these sensitive fields are sent even if empty in `config/autobackup_model.go`.

## How Has This Been Tested?

Fully tested with the Pexip Terraform provider.