### PR TITLE
Update Autobackup method to use PatchJSON instead of PutJSON

### DIFF
--- a/config/autobackup.go
+++ b/config/autobackup.go
@@ -24,6 +24,6 @@ func (s *Service) UpdateAutobackup(ctx context.Context, req *AutobackupUpdateReq
 	endpoint := "configuration/v1/autobackup/1/"
 
 	var result Autobackup
-	err := s.client.PutJSON(ctx, endpoint, req, &result)
+	err := s.client.PatchJSON(ctx, endpoint, req, &result)
 	return &result, err
 }

--- a/config/autobackup_test.go
+++ b/config/autobackup_test.go
@@ -66,7 +66,7 @@ func TestService_UpdateAutobackup(t *testing.T) {
 		AutobackupUploadPassword: "backuppass",
 	}
 
-	client.On("PutJSON", t.Context(), "configuration/v1/autobackup/1/", updateRequest, mock.AnythingOfType("*config.Autobackup")).Return(nil).Run(func(args mock.Arguments) {
+	client.On("PatchJSON", t.Context(), "configuration/v1/autobackup/1/", updateRequest, mock.AnythingOfType("*config.Autobackup")).Return(nil).Run(func(args mock.Arguments) {
 		result := args.Get(3).(*Autobackup)
 		*result = *expectedAutobackup
 	})


### PR DESCRIPTION
This was supposed to have been fixed in https://github.com/pexip/go-infinity-sdk/commit/d35310715f86500bdf75953af7c582c8f72a609b but for some reason the fix wasn't included. The API doesn't support PUT for this resource.