### PR TITLE
Add MinPinLength field to GlobalConfiguration and update request model

### DIFF
--- a/config/global_configuration_model.go
+++ b/config/global_configuration_model.go
@@ -105,6 +105,7 @@ type GlobalConfiguration struct {
 	MaxPresentationBandwidthRatio       int          `json:"max_presentation_bandwidth_ratio,omitempty"`
 	MediaPortsEnd                       int          `json:"media_ports_end,omitempty"`
 	MediaPortsStart                     int          `json:"media_ports_start,omitempty"`
+	MinPinLength                        int          `json:"min_pin_length,omitempty"`
 	OcspResponderURL                    string       `json:"ocsp_responder_url,omitempty"`
 	OcspState                           string       `json:"ocsp_state,omitempty"`
 	PinEntryTimeout                     int          `json:"pin_entry_timeout,omitempty"`
@@ -196,6 +197,7 @@ type GlobalConfigurationUpdateRequest struct {
 	MaxPresentationBandwidthRatio       int          `json:"max_presentation_bandwidth_ratio"`
 	MediaPortsEnd                       int          `json:"media_ports_end"`
 	MediaPortsStart                     int          `json:"media_ports_start"`
+	MinPinLength                        int          `json:"min_pin_length"`
 	OcspResponderURL                    string       `json:"ocsp_responder_url"`
 	OcspState                           string       `json:"ocsp_state"`
 	PinEntryTimeout                     int          `json:"pin_entry_timeout"`


### PR DESCRIPTION
This PR adds the field `min_pin_length` to the global configuration endpoint.