### PR TITLE
Add TLS client certificate support to ManagementVM and WorkerVM models

### DIFF
--- a/config/management_vm_model.go
+++ b/config/management_vm_model.go
@@ -28,6 +28,7 @@ type ManagementVM struct {
 	EventSinks                  []EventSink         `json:"event_sinks,omitempty"`
 	HTTPProxy                   *string             `json:"http_proxy,omitempty"`
 	TLSCertificate              *string             `json:"tls_certificate,omitempty"`
+	TLSClientCertificate        *string             `json:"tls_client_certificate,omitempty"`
 	EnableSSH                   string              `json:"enable_ssh"`
 	SSHAuthorizedKeys           []string            `json:"ssh_authorized_keys,omitempty"`
 	SSHAuthorizedKeysUseCloud   bool           `json:"ssh_authorized_keys_use_cloud"`
@@ -66,6 +67,7 @@ type ManagementVMCreateRequest struct {
 	EventSinks                  []string `json:"event_sinks,omitempty"`
 	HTTPProxy                   *string  `json:"http_proxy,omitempty"`
 	TLSCertificate              *string  `json:"tls_certificate,omitempty"`
+	TLSClientCertificate        *string  `json:"tls_client_certificate,omitempty"`
 	EnableSSH                   string   `json:"enable_ssh"`
 	SSHAuthorizedKeys           []string `json:"ssh_authorized_keys,omitempty"`
 	SSHAuthorizedKeysUseCloud   bool     `json:"ssh_authorized_keys_use_cloud"`
@@ -102,6 +104,7 @@ type ManagementVMUpdateRequest struct {
 	EventSinks                  []string `json:"event_sinks"`
 	HTTPProxy                   *string  `json:"http_proxy"`
 	TLSCertificate              *string  `json:"tls_certificate"`
+	TLSClientCertificate        *string  `json:"tls_client_certificate"`
 	EnableSSH                   string   `json:"enable_ssh,omitempty"`
 	SSHAuthorizedKeys           []string `json:"ssh_authorized_keys"`
 	SSHAuthorizedKeysUseCloud   bool     `json:"ssh_authorized_keys_use_cloud"`

--- a/config/worker_vm_model.go
+++ b/config/worker_vm_model.go
@@ -32,6 +32,7 @@ type WorkerVM struct {
 	IPv6Address                *string       `json:"ipv6_address,omitempty"`
 	IPv6Gateway                *string       `json:"ipv6_gateway,omitempty"`
 	TLSCertificate             *string       `json:"tls_certificate,omitempty"`
+	TLSClientCertificate       *string       `json:"tls_client_certificate,omitempty"`
 	SecondaryAddress           *string       `json:"secondary_address,omitempty"`
 	SecondaryNetmask           *string       `json:"secondary_netmask,omitempty"`
 	MediaPriorityWeight        *int          `json:"media_priority_weight,omitempty"`
@@ -79,11 +80,12 @@ type WorkerVMCreateRequest struct {
 	IPv6Address                *string  `json:"ipv6_address,omitempty"`
 	IPv6Gateway                *string  `json:"ipv6_gateway,omitempty"`
 	TLSCertificate             *string  `json:"tls_certificate,omitempty"`
+	TLSClientCertificate       *string  `json:"tls_client_certificate,omitempty"`
 	SecondaryAddress           *string  `json:"secondary_address,omitempty"`
 	SecondaryNetmask           *string  `json:"secondary_netmask,omitempty"`
 	MediaPriorityWeight        *int     `json:"media_priority_weight,omitempty"`
 	SSHAuthorizedKeys          []string `json:"ssh_authorized_keys,omitempty"`
-	SSHAuthorizedKeysUseCloud  bool     `json:"ssh_authorized_keys_use_cloud,omitempty"`
+	SSHAuthorizedKeysUseCloud  bool     `json:"ssh_authorized_keys_use_cloud"`
 	StaticNATAddress           *string  `json:"static_nat_address,omitempty"`
 	StaticRoutes               []string `json:"static_routes,omitempty"`
 	SNMPAuthenticationPassword string   `json:"snmp_authentication_password,omitempty"`
@@ -125,6 +127,7 @@ type WorkerVMUpdateRequest struct {
 	IPv6Address                *string  `json:"ipv6_address"`
 	IPv6Gateway                *string  `json:"ipv6_gateway"`
 	TLSCertificate             *string  `json:"tls_certificate"`
+	TLSClientCertificate       *string  `json:"tls_client_certificate"`
 	SecondaryAddress           *string  `json:"secondary_address"`
 	SecondaryNetmask           *string  `json:"secondary_netmask"`
 	MediaPriorityWeight        *int     `json:"media_priority_weight"`


### PR DESCRIPTION
This PR adds the field `tls_client_certificate` to the `worker_vm` and `management_vm` configuration resources. It also removes `omitempty` from `ssh_authorized_keys_use_cloud` for `worker_vm` which allows the setting to be cleared by the Terraform provider.