### PR TITLE
Change IVRTheme type from string to IVRTheme struct in GatewayRouting…

### DIFF
--- a/config/gateway_routing_rule_model.go
+++ b/config/gateway_routing_rule_model.go
@@ -39,7 +39,7 @@ type GatewayRoutingRule struct {
 	TURNServer                      *string           `json:"turn_server,omitempty"`
 	GMSAccessToken                  *string           `json:"gms_access_token,omitempty"`
 	TelehealthProfile               *string           `json:"telehealth_profile,omitempty"`
-	IVRTheme                        *string           `json:"ivr_theme,omitempty"`
+	IVRTheme                        *IVRTheme         `json:"ivr_theme,omitempty"`
 	MaxPixelsPerSecond              *string           `json:"max_pixels_per_second,omitempty"`
 	MaxCallrateIn                   *int              `json:"max_callrate_in,omitempty"`
 	MaxCallrateOut                  *int              `json:"max_callrate_out,omitempty"`


### PR DESCRIPTION
This PR fixes a bug when reading a gateway routing rule that has an IVR theme configured. Infinity returns an IVR theme object, not the resource URI. This would cause an error when unmarshalling the JSON response.