### PR TITLE
Update go-infinity-sdk to v40

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A comprehensive Go client library for the Pexip Infinity Management API, providi
 ## Installation
 
 ```bash
-go get github.com/pexip/go-infinity-sdk/v38
+go get github.com/pexip/go-infinity-sdk/v40
 ```
 
 ## Quick Start
@@ -32,7 +32,7 @@ import (
     "fmt"
     "log"
 
-    infinity "github.com/pexip/go-infinity-sdk/v38"
+    infinity "github.com/pexip/go-infinity-sdk/v40"
 )
 
 func main() {
@@ -78,7 +78,7 @@ client, err := infinity.New(
 
 #### Bearer Authentication
 ```go
-import "github.com/pexip/go-infinity-sdk/v38/auth"
+import "github.com/pexip/go-infinity-sdk/v40/auth"
 
 client, err := infinity.New(
     infinity.WithBaseURL("https://your-pexip-server.com"),
@@ -88,7 +88,7 @@ client, err := infinity.New(
 
 #### Custom Authentication
 ```go
-import "github.com/pexip/go-infinity-sdk/v38/auth"
+import "github.com/pexip/go-infinity-sdk/v40/auth"
 
 client, err := infinity.New(
     infinity.WithBaseURL("https://your-pexip-server.com"),
@@ -168,8 +168,8 @@ import (
     "fmt"
     "log"
 
-    infinity "github.com/pexip/go-infinity-sdk/v38"
-    "github.com/pexip/go-infinity-sdk/v38/config"
+    infinity "github.com/pexip/go-infinity-sdk/v40"
+    "github.com/pexip/go-infinity-sdk/v40/config"
 )
 
 func main() {
@@ -272,8 +272,8 @@ import (
     "fmt"
     "log"
 
-    infinity "github.com/pexip/go-infinity-sdk/v38"
-    "github.com/pexip/go-infinity-sdk/v38/status"
+    infinity "github.com/pexip/go-infinity-sdk/v40"
+    "github.com/pexip/go-infinity-sdk/v40/status"
 )
 
 func main() {
@@ -380,8 +380,8 @@ import (
     "log"
     "time"
 
-    infinity "github.com/pexip/go-infinity-sdk/v38"
-    "github.com/pexip/go-infinity-sdk/v38/history"
+    infinity "github.com/pexip/go-infinity-sdk/v40"
+    "github.com/pexip/go-infinity-sdk/v40/history"
 )
 
 func main() {
@@ -467,8 +467,8 @@ import (
     "fmt"
     "log"
 
-    infinity "github.com/pexip/go-infinity-sdk/v38"
-    "github.com/pexip/go-infinity-sdk/v38/command"
+    infinity "github.com/pexip/go-infinity-sdk/v40"
+    "github.com/pexip/go-infinity-sdk/v40/command"
 )
 
 func main() {
@@ -638,7 +638,7 @@ tlsClient, err := infinity.New(
 ### Error Handling
 
 ```go
-import "github.com/pexip/go-infinity-sdk/v38"
+import "github.com/pexip/go-infinity-sdk/v40"
 
 // All API calls return typed errors
 conferences, err := client.Config.ListConferences(ctx, nil)

--- a/client.go
+++ b/client.go
@@ -22,12 +22,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/auth"
-	"github.com/pexip/go-infinity-sdk/v38/command"
-	"github.com/pexip/go-infinity-sdk/v38/config"
-	"github.com/pexip/go-infinity-sdk/v38/history"
-	"github.com/pexip/go-infinity-sdk/v38/status"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/auth"
+	"github.com/pexip/go-infinity-sdk/v40/command"
+	"github.com/pexip/go-infinity-sdk/v40/config"
+	"github.com/pexip/go-infinity-sdk/v40/history"
+	"github.com/pexip/go-infinity-sdk/v40/status"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 const (

--- a/client_mock.go
+++ b/client_mock.go
@@ -11,12 +11,12 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/command"
-	"github.com/pexip/go-infinity-sdk/v38/config"
-	"github.com/pexip/go-infinity-sdk/v38/history"
-	"github.com/pexip/go-infinity-sdk/v38/status"
+	"github.com/pexip/go-infinity-sdk/v40/command"
+	"github.com/pexip/go-infinity-sdk/v40/config"
+	"github.com/pexip/go-infinity-sdk/v40/history"
+	"github.com/pexip/go-infinity-sdk/v40/status"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/client_option.go
+++ b/client_option.go
@@ -8,7 +8,7 @@ package infinity
 
 import (
 	"fmt"
-	"github.com/pexip/go-infinity-sdk/v38/auth"
+	"github.com/pexip/go-infinity-sdk/v40/auth"
 	"net/http"
 	"net/url"
 )

--- a/client_test.go
+++ b/client_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/auth"
+	"github.com/pexip/go-infinity-sdk/v40/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -173,7 +173,7 @@ func TestWithUserAgent(t *testing.T) {
 		},
 		{
 			name:      "another valid user agent",
-			userAgent: "go-infinity-sdk/v38",
+			userAgent: "go-infinity-sdk/v40",
 			wantErr:   false,
 		},
 		{

--- a/client_xml_test.go
+++ b/client_xml_test.go
@@ -13,7 +13,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/command/backup_test.go
+++ b/command/backup_test.go
@@ -7,7 +7,7 @@
 package command
 
 import (
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/command/command.go
+++ b/command/command.go
@@ -10,7 +10,7 @@
 package command
 
 import (
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 )
 
 // Service handles command API endpoints

--- a/command/conference_legacy_test.go
+++ b/command/conference_legacy_test.go
@@ -7,7 +7,7 @@
 package command
 
 import (
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/command/dial_test.go
+++ b/command/dial_test.go
@@ -9,7 +9,7 @@ package command
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/command/lock_test.go
+++ b/command/lock_test.go
@@ -9,7 +9,7 @@ package command
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/command/mute_guests_test.go
+++ b/command/mute_guests_test.go
@@ -9,7 +9,7 @@ package command
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/command/participant_legacy_test.go
+++ b/command/participant_legacy_test.go
@@ -9,7 +9,7 @@ package command
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/command/participant_test.go
+++ b/command/participant_test.go
@@ -9,7 +9,7 @@ package command
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/command/send_email_test.go
+++ b/command/send_email_test.go
@@ -9,7 +9,7 @@ package command
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/command/system_test.go
+++ b/command/system_test.go
@@ -9,7 +9,7 @@ package command
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/command/transform_layout_test.go
+++ b/command/transform_layout_test.go
@@ -9,7 +9,7 @@ package command
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/command/unlock_test.go
+++ b/command/unlock_test.go
@@ -9,7 +9,7 @@ package command
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/adfs_auth_server.go
+++ b/config/adfs_auth_server.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListADFSAuthServers retrieves a list of AD FS OAuth 2.0 Clients

--- a/config/adfs_auth_server_domain.go
+++ b/config/adfs_auth_server_domain.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListADFSAuthServerDomains retrieves a list of AD FS OAuth 2.0 Client domains

--- a/config/adfs_auth_server_domain_test.go
+++ b/config/adfs_auth_server_domain_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/adfs_auth_server_test.go
+++ b/config/adfs_auth_server_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/authentication_test.go
+++ b/config/authentication_test.go
@@ -9,7 +9,7 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/autobackup_test.go
+++ b/config/autobackup_test.go
@@ -9,7 +9,7 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/automatic_participant.go
+++ b/config/automatic_participant.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListAutomaticParticipants retrieves a list of automatic participants

--- a/config/automatic_participant_model.go
+++ b/config/automatic_participant_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // AutomaticParticipant represents an automatic participant configuration
 type AutomaticParticipant struct {

--- a/config/automatic_participant_test.go
+++ b/config/automatic_participant_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/azure_tenant.go
+++ b/config/azure_tenant.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListAzureTenants retrieves a list of Microsoft Teams tenants

--- a/config/azure_tenant_test.go
+++ b/config/azure_tenant_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/break_in_allow_list_address.go
+++ b/config/break_in_allow_list_address.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListBreakInAllowListAddresses retrieves a list of break-in attempt IP allow list entries

--- a/config/break_in_allow_list_address_test.go
+++ b/config/break_in_allow_list_address_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/ca_certificate.go
+++ b/config/ca_certificate.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListCACertificates retrieves a list of CA certificates

--- a/config/ca_certificate_model.go
+++ b/config/ca_certificate_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // CACertificate represents a CA certificate configuration
 type CACertificate struct {

--- a/config/ca_certificate_test.go
+++ b/config/ca_certificate_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/certificate_signing_request.go
+++ b/config/certificate_signing_request.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListCertificateSigningRequests retrieves a list of certificate signing requests

--- a/config/certificate_signing_request_test.go
+++ b/config/certificate_signing_request_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/conference.go
+++ b/config/conference.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListConferences retrieves a list of conferences

--- a/config/conference_alias.go
+++ b/config/conference_alias.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListConferenceAliases retrieves a list of conference aliases

--- a/config/conference_alias_model.go
+++ b/config/conference_alias_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // ConferenceAlias represents a conference alias configuration
 type ConferenceAlias struct {

--- a/config/conference_alias_test.go
+++ b/config/conference_alias_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/conference_model.go
+++ b/config/conference_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // Conference represents a conference configuration
 type Conference struct {

--- a/config/conference_sync_template.go
+++ b/config/conference_sync_template.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListConferenceSyncTemplates retrieves a list of conference sync templates

--- a/config/conference_sync_template_test.go
+++ b/config/conference_sync_template_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/conference_test.go
+++ b/config/conference_test.go
@@ -10,9 +10,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,7 @@
 package config
 
 import (
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 )
 
 // Service handles Configuration API endpoints

--- a/config/core_model.go
+++ b/config/core_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/options"
+import "github.com/pexip/go-infinity-sdk/v40/options"
 
 // ListOptions contains options for listing resources
 type ListOptions = options.SearchableListOptions

--- a/config/device.go
+++ b/config/device.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListDevices retrieves a list of devices

--- a/config/device_model.go
+++ b/config/device_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // Device represents a device configuration
 type Device struct {

--- a/config/device_test.go
+++ b/config/device_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/diagnostic_graphs.go
+++ b/config/diagnostic_graphs.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListDiagnosticGraphs retrieves a list of diagnostic graphs

--- a/config/diagnostic_graphs_test.go
+++ b/config/diagnostic_graphs_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/dns_server.go
+++ b/config/dns_server.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListDNSServers retrieves a list of DNS servers

--- a/config/dns_server_test.go
+++ b/config/dns_server_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/end_user.go
+++ b/config/end_user.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListEndUsers retrieves a list of end users

--- a/config/end_user_test.go
+++ b/config/end_user_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/event_sink.go
+++ b/config/event_sink.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListEventSinks retrieves a list of event sinks

--- a/config/event_sink_model.go
+++ b/config/event_sink_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // EventSink represents an event sink configuration
 type EventSink struct {

--- a/config/event_sink_test.go
+++ b/config/event_sink_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/exchange_domain.go
+++ b/config/exchange_domain.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListExchangeDomains retrieves a list of Exchange Metadata Domains

--- a/config/exchange_domain_model.go
+++ b/config/exchange_domain_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // ExchangeDomain represents an Exchange Metadata Domain configuration
 type ExchangeDomain struct {

--- a/config/exchange_domain_test.go
+++ b/config/exchange_domain_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/external_webapp_host.go
+++ b/config/external_webapp_host.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListExternalWebappHosts retrieves a list of external web app hosts

--- a/config/external_webapp_host_test.go
+++ b/config/external_webapp_host_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/gateway_routing_rule.go
+++ b/config/gateway_routing_rule.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListGatewayRoutingRules retrieves a list of gateway routing rules

--- a/config/gateway_routing_rule_model.go
+++ b/config/gateway_routing_rule_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // GatewayRoutingRule represents a gateway routing rule configuration
 type GatewayRoutingRule struct {

--- a/config/gateway_routing_rule_test.go
+++ b/config/gateway_routing_rule_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/global_configuration_test.go
+++ b/config/global_configuration_test.go
@@ -9,7 +9,7 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/gms_access_token.go
+++ b/config/gms_access_token.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListGMSAccessTokens retrieves a list of Google Meet access tokens

--- a/config/gms_access_token_test.go
+++ b/config/gms_access_token_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/gms_gateway_token_test.go
+++ b/config/gms_gateway_token_test.go
@@ -9,7 +9,7 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/google_auth_server.go
+++ b/config/google_auth_server.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListGoogleAuthServers retrieves a list of Google OAuth 2.0 Credentials

--- a/config/google_auth_server_domain.go
+++ b/config/google_auth_server_domain.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListGoogleAuthServerDomains retrieves a list of Google OAuth 2.0 Credential domains

--- a/config/google_auth_server_domain_test.go
+++ b/config/google_auth_server_domain_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/google_auth_server_test.go
+++ b/config/google_auth_server_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/h323_gatekeeper.go
+++ b/config/h323_gatekeeper.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListH323Gatekeepers retrieves a list of H.323 gatekeepers

--- a/config/h323_gatekeeper_test.go
+++ b/config/h323_gatekeeper_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/http_proxy.go
+++ b/config/http_proxy.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListHTTPProxies retrieves a list of HTTP proxies

--- a/config/http_proxy_test.go
+++ b/config/http_proxy_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/identity_provider.go
+++ b/config/identity_provider.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListIdentityProviders retrieves a list of identity providers

--- a/config/identity_provider_attribute.go
+++ b/config/identity_provider_attribute.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListIdentityProviderAttributes retrieves a list of identity provider attributes

--- a/config/identity_provider_attribute_test.go
+++ b/config/identity_provider_attribute_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/identity_provider_group.go
+++ b/config/identity_provider_group.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListIdentityProviderGroups retrieves a list of identity provider groups

--- a/config/identity_provider_group_test.go
+++ b/config/identity_provider_group_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/identity_provider_test.go
+++ b/config/identity_provider_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/ivr_theme.go
+++ b/config/ivr_theme.go
@@ -13,7 +13,7 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListIVRThemes retrieves a list of IVR themes

--- a/config/ivr_theme_model.go
+++ b/config/ivr_theme_model.go
@@ -7,7 +7,7 @@
 package config
 
 import (
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 )
 
 // IVRTheme represents an IVR theme configuration

--- a/config/ivr_theme_test.go
+++ b/config/ivr_theme_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/ldap_role.go
+++ b/config/ldap_role.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListLdapRoles retrieves a list of LDAP roles

--- a/config/ldap_role_test.go
+++ b/config/ldap_role_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/ldap_sync_field.go
+++ b/config/ldap_sync_field.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListLdapSyncFields retrieves a list of LDAP sync fields

--- a/config/ldap_sync_field_test.go
+++ b/config/ldap_sync_field_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/ldap_sync_source.go
+++ b/config/ldap_sync_source.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListLdapSyncSources retrieves a list of LDAP sync sources

--- a/config/ldap_sync_source_test.go
+++ b/config/ldap_sync_source_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/licence.go
+++ b/config/licence.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListLicences retrieves a list of licences

--- a/config/licence_request.go
+++ b/config/licence_request.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListLicenceRequests retrieves a list of licence requests

--- a/config/licence_request_test.go
+++ b/config/licence_request_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/licence_test.go
+++ b/config/licence_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/log_level.go
+++ b/config/log_level.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListLogLevels retrieves a list of log levels

--- a/config/log_level_test.go
+++ b/config/log_level_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/management_vm_test.go
+++ b/config/management_vm_test.go
@@ -9,7 +9,7 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/media_library_entry.go
+++ b/config/media_library_entry.go
@@ -12,7 +12,7 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListMediaLibraryEntries retrieves a list of media library entries

--- a/config/media_library_entry_test.go
+++ b/config/media_library_entry_test.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/media_library_playlist.go
+++ b/config/media_library_playlist.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListMediaLibraryPlaylists retrieves a list of media library playlists

--- a/config/media_library_playlist_entry.go
+++ b/config/media_library_playlist_entry.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListMediaLibraryPlaylistEntries retrieves a list of media library playlist entries

--- a/config/media_library_playlist_entry_test.go
+++ b/config/media_library_playlist_entry_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/media_library_playlist_test.go
+++ b/config/media_library_playlist_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/media_processing_server.go
+++ b/config/media_processing_server.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListMediaProcessingServers retrieves a list of media processing servers

--- a/config/media_processing_server_test.go
+++ b/config/media_processing_server_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/mjx_endpoint.go
+++ b/config/mjx_endpoint.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListMjxEndpoints retrieves a list of MJX endpoints

--- a/config/mjx_endpoint_group.go
+++ b/config/mjx_endpoint_group.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListMjxEndpointGroups retrieves a list of MJX endpoint groups

--- a/config/mjx_endpoint_group_test.go
+++ b/config/mjx_endpoint_group_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/mjx_endpoint_test.go
+++ b/config/mjx_endpoint_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/mjx_exchange_autodiscover_url.go
+++ b/config/mjx_exchange_autodiscover_url.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListMjxExchangeAutodiscoverURLs retrieves a list of MJX Exchange autodiscover URLs

--- a/config/mjx_exchange_autodiscover_url_test.go
+++ b/config/mjx_exchange_autodiscover_url_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/mjx_exchange_deployment.go
+++ b/config/mjx_exchange_deployment.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListMjxExchangeDeployments retrieves a list of MJX Exchange deployments

--- a/config/mjx_exchange_deployment_test.go
+++ b/config/mjx_exchange_deployment_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/mjx_google_deployment.go
+++ b/config/mjx_google_deployment.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListMjxGoogleDeployments retrieves a list of MJX Google deployments

--- a/config/mjx_google_deployment_test.go
+++ b/config/mjx_google_deployment_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/mjx_graph_deployment.go
+++ b/config/mjx_graph_deployment.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListMjxGraphDeployments retrieves a list of MJX Graph deployments

--- a/config/mjx_graph_deployment_test.go
+++ b/config/mjx_graph_deployment_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/mjx_integration.go
+++ b/config/mjx_integration.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListMjxIntegrations retrieves a list of MJX integrations

--- a/config/mjx_integration_test.go
+++ b/config/mjx_integration_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/mjx_meeting_processing_rule.go
+++ b/config/mjx_meeting_processing_rule.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListMjxMeetingProcessingRules retrieves a list of MJX meeting processing rules

--- a/config/mjx_meeting_processing_rule_test.go
+++ b/config/mjx_meeting_processing_rule_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/ms_exchange_connector.go
+++ b/config/ms_exchange_connector.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListMsExchangeConnectors retrieves a list of Microsoft Exchange connectors

--- a/config/ms_exchange_connector_test.go
+++ b/config/ms_exchange_connector_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/mssip_proxy.go
+++ b/config/mssip_proxy.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListMSSIPProxies retrieves a list of MS-SIP proxies

--- a/config/mssip_proxy_test.go
+++ b/config/mssip_proxy_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/ntp_server.go
+++ b/config/ntp_server.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListNTPServers retrieves a list of NTP servers

--- a/config/ntp_server_test.go
+++ b/config/ntp_server_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/oauth2_client.go
+++ b/config/oauth2_client.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListOAuth2Clients retrieves a list of OAuth2 clients

--- a/config/oauth2_client_test.go
+++ b/config/oauth2_client_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/permission_test.go
+++ b/config/permission_test.go
@@ -9,8 +9,8 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/pexip_streaming_credential.go
+++ b/config/pexip_streaming_credential.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListPexipStreamingCredentials retrieves a list of Pexip Streaming credentials

--- a/config/pexip_streaming_credential_test.go
+++ b/config/pexip_streaming_credential_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/policy_server.go
+++ b/config/policy_server.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListPolicyServers retrieves a list of policy servers

--- a/config/policy_server_test.go
+++ b/config/policy_server_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/recurring_conference.go
+++ b/config/recurring_conference.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListRecurringConferences retrieves a list of recurring conferences

--- a/config/recurring_conference_test.go
+++ b/config/recurring_conference_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/registration_test.go
+++ b/config/registration_test.go
@@ -9,7 +9,7 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/role.go
+++ b/config/role.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListRoles retrieves a list of roles

--- a/config/role_mapping.go
+++ b/config/role_mapping.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListRoleMappings retrieves a list of role mappings

--- a/config/role_mapping_test.go
+++ b/config/role_mapping_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/role_test.go
+++ b/config/role_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/scheduled_alias.go
+++ b/config/scheduled_alias.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListScheduledAliases retrieves a list of scheduled aliases

--- a/config/scheduled_alias_model.go
+++ b/config/scheduled_alias_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // ScheduledAlias represents a scheduled alias configuration
 type ScheduledAlias struct {

--- a/config/scheduled_alias_test.go
+++ b/config/scheduled_alias_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/scheduled_conference.go
+++ b/config/scheduled_conference.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListScheduledConferences retrieves a list of scheduled conferences

--- a/config/scheduled_conference_model.go
+++ b/config/scheduled_conference_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // ScheduledConference represents a scheduled conference configuration
 type ScheduledConference struct {

--- a/config/scheduled_conference_test.go
+++ b/config/scheduled_conference_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/scheduled_scaling.go
+++ b/config/scheduled_scaling.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListScheduledScalings retrieves a list of scheduled scaling policies

--- a/config/scheduled_scaling_model.go
+++ b/config/scheduled_scaling_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // ScheduledScaling represents a scheduled scaling policy configuration
 type ScheduledScaling struct {

--- a/config/scheduled_scaling_test.go
+++ b/config/scheduled_scaling_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/sip_credential.go
+++ b/config/sip_credential.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListSIPCredentials retrieves a list of SIP credentials

--- a/config/sip_credential_test.go
+++ b/config/sip_credential_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/sip_proxy.go
+++ b/config/sip_proxy.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListSIPProxies retrieves a list of SIP proxies

--- a/config/sip_proxy_test.go
+++ b/config/sip_proxy_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/smtp_server.go
+++ b/config/smtp_server.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListSMTPServers retrieves a list of SMTP servers

--- a/config/smtp_server_test.go
+++ b/config/smtp_server_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/snmp_network_management_system.go
+++ b/config/snmp_network_management_system.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListSnmpNetworkManagementSystems retrieves a list of SNMP network management systems

--- a/config/snmp_network_management_system_test.go
+++ b/config/snmp_network_management_system_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/software_bundle_revision_test.go
+++ b/config/software_bundle_revision_test.go
@@ -9,8 +9,8 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/software_bundle_test.go
+++ b/config/software_bundle_test.go
@@ -9,8 +9,8 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/ssh_authorized_key.go
+++ b/config/ssh_authorized_key.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListSSHAuthorizedKeys retrieves a list of SSH authorized keys

--- a/config/ssh_authorized_key_test.go
+++ b/config/ssh_authorized_key_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/static_route.go
+++ b/config/static_route.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListStaticRoutes retrieves a list of static routes

--- a/config/static_route_test.go
+++ b/config/static_route_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/stun_server.go
+++ b/config/stun_server.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListSTUNServers retrieves a list of STUN servers

--- a/config/stun_server_test.go
+++ b/config/stun_server_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/syslog_server.go
+++ b/config/syslog_server.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListSyslogServers retrieves a list of syslog servers

--- a/config/syslog_server_test.go
+++ b/config/syslog_server_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/system_backup_model.go
+++ b/config/system_backup_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // SystemBackup represents a system backup configuration
 type SystemBackup struct {

--- a/config/system_backup_test.go
+++ b/config/system_backup_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/system_location.go
+++ b/config/system_location.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListSystemLocations retrieves a list of system locations

--- a/config/system_location_test.go
+++ b/config/system_location_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/system_syncpoint.go
+++ b/config/system_syncpoint.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // CreateSystemSyncpoint creates a new system syncpoint

--- a/config/system_syncpoint_model.go
+++ b/config/system_syncpoint_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // SystemSyncpoint represents a system syncpoint configuration
 type SystemSyncpoint struct {

--- a/config/system_syncpoint_test.go
+++ b/config/system_syncpoint_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/types"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/types"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/system_tuneable.go
+++ b/config/system_tuneable.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListSystemTuneables retrieves a list of system tuneables

--- a/config/system_tuneable_test.go
+++ b/config/system_tuneable_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/teams_proxy.go
+++ b/config/teams_proxy.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListTeamsProxies retrieves a list of Teams proxies

--- a/config/teams_proxy_model.go
+++ b/config/teams_proxy_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // TeamsProxy represents a Teams proxy configuration
 type TeamsProxy struct {

--- a/config/teams_proxy_test.go
+++ b/config/teams_proxy_test.go
@@ -9,10 +9,10 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/telehealth_profile.go
+++ b/config/telehealth_profile.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListTelehealthProfiles retrieves a list of telehealth profiles

--- a/config/telehealth_profile_test.go
+++ b/config/telehealth_profile_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/tls_certificate.go
+++ b/config/tls_certificate.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListTLSCertificates retrieves a list of TLS certificates

--- a/config/tls_certificate_model.go
+++ b/config/tls_certificate_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // TLSCertificate represents a TLS certificate configuration
 type TLSCertificate struct {

--- a/config/tls_certificate_test.go
+++ b/config/tls_certificate_test.go
@@ -9,10 +9,10 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/turn_server.go
+++ b/config/turn_server.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListTURNServers retrieves a list of TURN servers

--- a/config/turn_server_test.go
+++ b/config/turn_server_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/upgrade.go
+++ b/config/upgrade.go
@@ -9,7 +9,7 @@ package config
 import (
 	"context"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // CreateUpgrade initiates a system upgrade (POST only)

--- a/config/upgrade_test.go
+++ b/config/upgrade_test.go
@@ -9,8 +9,8 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/config/user_group.go
+++ b/config/user_group.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListUserGroups retrieves a list of user groups

--- a/config/user_group_entity_mapping.go
+++ b/config/user_group_entity_mapping.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListUserGroupEntityMappings retrieves a list of user group entity mappings

--- a/config/user_group_entity_mapping_test.go
+++ b/config/user_group_entity_mapping_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/user_group_test.go
+++ b/config/user_group_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/webapp_alias.go
+++ b/config/webapp_alias.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListWebappAliases retrieves a list of web app aliases

--- a/config/webapp_alias_test.go
+++ b/config/webapp_alias_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/webapp_branding.go
+++ b/config/webapp_branding.go
@@ -11,7 +11,7 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListWebappBrandings retrieves a list of webapp brandings

--- a/config/webapp_branding_model.go
+++ b/config/webapp_branding_model.go
@@ -6,7 +6,7 @@
 
 package config
 
-import "github.com/pexip/go-infinity-sdk/v38/util"
+import "github.com/pexip/go-infinity-sdk/v40/util"
 
 // WebappBranding represents a webapp branding configuration
 type WebappBranding struct {

--- a/config/webapp_branding_test.go
+++ b/config/webapp_branding_test.go
@@ -9,10 +9,10 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config/worker_vm.go
+++ b/config/worker_vm.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // ListWorkerVMs retrieves a list of worker VMs

--- a/config/worker_vm_test.go
+++ b/config/worker_vm_test.go
@@ -9,9 +9,9 @@ package config
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/config_module_integration_test.go
+++ b/config_module_integration_test.go
@@ -10,7 +10,7 @@ package infinity
 
 import (
 	"crypto/tls"
-	"github.com/pexip/go-infinity-sdk/v38/config"
+	"github.com/pexip/go-infinity-sdk/v40/config"
 	"github.com/stretchr/testify/require"
 	"net/http"
 	"os"

--- a/example/main.go
+++ b/example/main.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"log"
 
-	infinity "github.com/pexip/go-infinity-sdk/v38"
-	"github.com/pexip/go-infinity-sdk/v38/config"
+	infinity "github.com/pexip/go-infinity-sdk/v40"
+	"github.com/pexip/go-infinity-sdk/v40/config"
 )
 
 func main() {

--- a/example/transport/main.go
+++ b/example/transport/main.go
@@ -15,7 +15,7 @@ import (
 	"net/url"
 	"time"
 
-	infinity "github.com/pexip/go-infinity-sdk/v38"
+	infinity "github.com/pexip/go-infinity-sdk/v40"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pexip/go-infinity-sdk/v38
+module github.com/pexip/go-infinity-sdk/v40
 
 go 1.24.3
 

--- a/history/alarm_test.go
+++ b/history/alarm_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/history/backplane_media_stream_test.go
+++ b/history/backplane_media_stream_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/history/backplane_test.go
+++ b/history/backplane_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/history/conference_record_test.go
+++ b/history/conference_record_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/history/history.go
+++ b/history/history.go
@@ -14,7 +14,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 )
 
 // Service handles history API endpoints

--- a/history/media_stream_test.go
+++ b/history/media_stream_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/history/models.go
+++ b/history/models.go
@@ -7,8 +7,8 @@
 package history
 
 import (
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 )
 
 // ListOptions contains options for listing historical records

--- a/history/participant_test.go
+++ b/history/participant_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/history/registration_alias_test.go
+++ b/history/registration_alias_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/history/workervm_status_event_test.go
+++ b/history/workervm_status_event_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/interfaces/client.go
+++ b/interfaces/client.go
@@ -13,7 +13,7 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 )
 
 // HTTPClient defines the interface for HTTP operations used by the SDK services.

--- a/interfaces/mock.go
+++ b/interfaces/mock.go
@@ -11,7 +11,7 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/types"
+	"github.com/pexip/go-infinity-sdk/v40/types"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/status/alarm_test.go
+++ b/status/alarm_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	util "github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	util "github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/backplane_test.go
+++ b/status/backplane_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	util "github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	util "github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/backup_request_test.go
+++ b/status/backup_request_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/cloud_monitored_location_test.go
+++ b/status/cloud_monitored_location_test.go
@@ -9,7 +9,7 @@ package status
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/cloud_node_test.go
+++ b/status/cloud_node_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	util "github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	util "github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/cloud_overflow_location_test.go
+++ b/status/cloud_overflow_location_test.go
@@ -9,7 +9,7 @@ package status
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/conference_shard_test.go
+++ b/status/conference_shard_test.go
@@ -9,7 +9,7 @@ package status
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/conference_sync_test.go
+++ b/status/conference_sync_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	util "github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	util "github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/conference_test.go
+++ b/status/conference_test.go
@@ -9,7 +9,7 @@ package status
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/exchange_scheduler_test.go
+++ b/status/exchange_scheduler_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/licensing_test.go
+++ b/status/licensing_test.go
@@ -9,7 +9,7 @@ package status
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/management_vm_test.go
+++ b/status/management_vm_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/mjx_endpoint_test.go
+++ b/status/mjx_endpoint_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/mjx_meeting_test.go
+++ b/status/mjx_meeting_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/models.go
+++ b/status/models.go
@@ -7,7 +7,7 @@
 package status
 
 import (
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 )
 
 // Meta represents the pagination metadata for list responses

--- a/status/participant_test.go
+++ b/status/participant_test.go
@@ -9,8 +9,8 @@ package status
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/registration_alias_test.go
+++ b/status/registration_alias_test.go
@@ -9,7 +9,7 @@ package status
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/scheduling_operation_test.go
+++ b/status/scheduling_operation_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/snapshot_request_test.go
+++ b/status/snapshot_request_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/status.go
+++ b/status/status.go
@@ -13,8 +13,8 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/options"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/options"
 )
 
 // Service handles status API endpoints

--- a/status/system_location_test.go
+++ b/status/system_location_test.go
@@ -9,7 +9,7 @@ package status
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/system_status_test.go
+++ b/status/system_status_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/teamsnode_call_test.go
+++ b/status/teamsnode_call_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/teamsnode_test.go
+++ b/status/teamsnode_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
-	"github.com/pexip/go-infinity-sdk/v38/util"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/status/worker_vm_test.go
+++ b/status/worker_vm_test.go
@@ -9,7 +9,7 @@ package status
 import (
 	"testing"
 
-	"github.com/pexip/go-infinity-sdk/v38/interfaces"
+	"github.com/pexip/go-infinity-sdk/v40/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )


### PR DESCRIPTION
This pull request updates the Go Infinity SDK from version v38 to v40 throughout the codebase and documentation. The main focus is to ensure all imports, references, and documentation examples consistently use the new v40 version, aligning the codebase with the latest SDK release.

**SDK Version Upgrade:**

* Updated all import paths from `github.com/pexip/go-infinity-sdk/v38` to `github.com/pexip/go-infinity-sdk/v40` across all source files, test files, and documentation, ensuring consistency and compatibility with the latest SDK version. [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL25-R30) [[2]](diffhunk://#diff-a0db6581c6956a98c5f92bff89ce82ae4b01dc43f09839f8c007daac4e4fd467L14-R19) [[3]](diffhunk://#diff-c056e12b68cd7786bf046daad35c85942651ee563e1d1145b3246c19e4f507dfL11-R11) [[4]](diffhunk://#diff-4dc56e64f310cd8c12bb00f75c09e83f5d875563ea9901788e525487dc6788b3L22-R22) [[5]](diffhunk://#diff-e0f409b6bf8ff7a081d6d3a02db40e3d717ca46b95c15a60d04f8f84480e688bL16-R16) [[6]](diffhunk://#diff-78b35b0400e10cd80d5d64821c38511fbc5bedfdea9e1f16c5344582f62f60d1L10-R10) [[7]](diffhunk://#diff-9411b7c0f7187e3e94ff7f48851c1d31db3607a56078f9aa6bb1ae80121efbcfL13-R13) [[8]](diffhunk://#diff-15aea0f512de6b4cb24894873240ee65d127d86b9c661f3653a2c53d667c54fcL10-R10) [[9]](diffhunk://#diff-4d2897436ed5879a3851f86f05e6286d5ad8cbc89a56536ce59437be96be995fL12-R12) [[10]](diffhunk://#diff-c4821c144355a92ef1cd87fb3354a881f403d81df7dec3b15888b54642362962L12-R12) [[11]](diffhunk://#diff-2bc5b092e8e95a618731b99c0c8960c251e9fefeb14b5dfbebf7a93d7d14f877L12-R12) [[12]](diffhunk://#diff-db3904e9ab8951a556c93d891a8d8c574873390ae9871d44a74f4465d16a7433L12-R12) [[13]](diffhunk://#diff-f0e6309c22a3d5c6426398a5ce9eca2879b957c49a5e8ae5b9e3008815a54689L12-R12) [[14]](diffhunk://#diff-e1318aff865cd48e9ed42b1ddbcede498c1745fb6101676059e04bd0d2f06802L12-R12) [[15]](diffhunk://#diff-d038801ce4f4f93eeca01d43b28917855b082c2492094623cd03e06d6d5be63cL12-R12) [[16]](diffhunk://#diff-99f00c74a2e1e0a96f20cd7fed77a394f07f64610086c70fb37ab7e7a1c2686eL12-R12) [[17]](diffhunk://#diff-894a06ab683fa87223c1ffefcf6638f695ad6c74d8d57d3fa95730015273c205L12-R12) [[18]](diffhunk://#diff-6017e0ffc91701bd78b269af15a9877054b8d0680ff2cdc5d75926b2ec6f5a0fL14-R14) [[19]](diffhunk://#diff-f5ac928462b3317a1d7f0e47f7d6e67111621bc7634a901c27e02cab8bae47dbL14-R14)

**Documentation Updates:**

* Updated all usage examples, installation instructions, and import statements in `README.md` to reference v40 instead of v38, ensuring that new users and existing users referencing the documentation are guided to use the latest SDK version. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R35) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R81) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L91-R91) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L171-R172) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L275-R276) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L383-R384) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L470-R471) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L641-R641)

**Test Suite Adjustments:**

* Updated test files and test data to use the new v40 version in import paths and user agent strings, maintaining alignment with the SDK upgrade and preventing test failures due to version mismatches.

No other functional or behavioral changes were introduced in this pull request.