### PR TITLE
Fix management_vm ID handling

### DIFF
--- a/config/management_vm.go
+++ b/config/management_vm.go
@@ -8,20 +8,45 @@ package config
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 )
 
-// GetManagementVM retrieves a specific management VM by ID
-func (s *Service) GetManagementVM(ctx context.Context) (*ManagementVM, error) {
-	endpoint := "configuration/v1/management_vm/1/"
+// ListManagementVMs retrieves a list of management VMs.
+func (s *Service) ListManagementVMs(ctx context.Context, opts *ListOptions) (*ManagementVMListResponse, error) {
+	endpoint := "configuration/v1/management_vm/"
+
+	var params *url.Values
+	if opts != nil {
+		urlValues := opts.ToURLValues()
+		params = &urlValues
+	}
+
+	var result ManagementVMListResponse
+	err := s.client.GetJSON(ctx, endpoint, params, &result)
+	return &result, err
+}
+
+// GetManagementVM retrieves a management VM by ID. If id is omitted, defaults to 1.
+func (s *Service) GetManagementVM(ctx context.Context, id ...int) (*ManagementVM, error) {
+	vmID := 1
+	if len(id) > 0 {
+		vmID = id[0]
+	}
+	endpoint := fmt.Sprintf("configuration/v1/management_vm/%d/", vmID)
 
 	var result ManagementVM
 	err := s.client.GetJSON(ctx, endpoint, nil, &result)
 	return &result, err
 }
 
-// UpdateManagementVM updates an existing management VM
-func (s *Service) UpdateManagementVM(ctx context.Context, req *ManagementVMUpdateRequest) (*ManagementVM, error) {
-	endpoint := "configuration/v1/management_vm/1/"
+// UpdateManagementVM updates an existing management VM by ID. If id is omitted, defaults to 1.
+func (s *Service) UpdateManagementVM(ctx context.Context, req *ManagementVMUpdateRequest, id ...int) (*ManagementVM, error) {
+	vmID := 1
+	if len(id) > 0 {
+		vmID = id[0]
+	}
+	endpoint := fmt.Sprintf("configuration/v1/management_vm/%d/", vmID)
 
 	var result ManagementVM
 	err := s.client.PatchJSON(ctx, endpoint, req, &result)

--- a/config/management_vm_test.go
+++ b/config/management_vm_test.go
@@ -74,7 +74,7 @@ func TestService_GetManagementVM(t *testing.T) {
 func TestService_GetManagementVM_ExplicitID(t *testing.T) {
 	client := interfaces.NewHTTPClientMock()
 
-	expected := &ManagementVM{ID: 3, Name: "pi2-mgr", Address: "172.21.33.135"}
+	expected := &ManagementVM{ID: 3, Name: "test-mgmt-vm", Address: "192.168.1.10"}
 
 	client.On("GetJSON", t.Context(), "configuration/v1/management_vm/3/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ManagementVM")).Return(nil).Run(func(args mock.Arguments) {
 		result := args.Get(3).(*ManagementVM)
@@ -115,8 +115,8 @@ func TestService_ListManagementVMs(t *testing.T) {
 func TestService_UpdateManagementVM(t *testing.T) {
 	client := interfaces.NewHTTPClientMock()
 
-	req := &ManagementVMUpdateRequest{Name: "updated-mgr", SNMPMode: "DISABLED"}
-	expected := &ManagementVM{ID: 1, Name: "updated-mgr"}
+	req := &ManagementVMUpdateRequest{Name: "test-mgmt-vm", SNMPMode: "DISABLED"}
+	expected := &ManagementVM{ID: 1, Name: "test-mgmt-vm"}
 
 	client.On("PatchJSON", t.Context(), "configuration/v1/management_vm/1/", req, mock.AnythingOfType("*config.ManagementVM")).Return(nil).Run(func(args mock.Arguments) {
 		result := args.Get(3).(*ManagementVM)
@@ -134,8 +134,8 @@ func TestService_UpdateManagementVM(t *testing.T) {
 func TestService_UpdateManagementVM_ExplicitID(t *testing.T) {
 	client := interfaces.NewHTTPClientMock()
 
-	req := &ManagementVMUpdateRequest{Name: "pi2-mgr", SNMPMode: "DISABLED"}
-	expected := &ManagementVM{ID: 3, Name: "pi2-mgr"}
+	req := &ManagementVMUpdateRequest{Name: "test-mgmt-vm", SNMPMode: "DISABLED"}
+	expected := &ManagementVM{ID: 3, Name: "test-mgmt-vm"}
 
 	client.On("PatchJSON", t.Context(), "configuration/v1/management_vm/3/", req, mock.AnythingOfType("*config.ManagementVM")).Return(nil).Run(func(args mock.Arguments) {
 		result := args.Get(3).(*ManagementVM)

--- a/config/management_vm_test.go
+++ b/config/management_vm_test.go
@@ -70,3 +70,82 @@ func TestService_GetManagementVM(t *testing.T) {
 	assert.Equal(t, expectedManagementVM, result)
 	client.AssertExpectations(t)
 }
+
+func TestService_GetManagementVM_ExplicitID(t *testing.T) {
+	client := interfaces.NewHTTPClientMock()
+
+	expected := &ManagementVM{ID: 3, Name: "pi2-mgr", Address: "172.21.33.135"}
+
+	client.On("GetJSON", t.Context(), "configuration/v1/management_vm/3/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ManagementVM")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ManagementVM)
+		*result = *expected
+	})
+
+	service := New(client)
+	result, err := service.GetManagementVM(t.Context(), 3)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	client.AssertExpectations(t)
+}
+
+func TestService_ListManagementVMs(t *testing.T) {
+	client := interfaces.NewHTTPClientMock()
+
+	expected := &ManagementVMListResponse{
+		Objects: []ManagementVM{
+			{ID: 1, Name: "primary-mgr"},
+			{ID: 2, Name: "secondary-mgr"},
+		},
+	}
+
+	client.On("GetJSON", t.Context(), "configuration/v1/management_vm/", mock.AnythingOfType("*url.Values"), mock.AnythingOfType("*config.ManagementVMListResponse")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ManagementVMListResponse)
+		*result = *expected
+	})
+
+	service := New(client)
+	result, err := service.ListManagementVMs(t.Context(), nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	client.AssertExpectations(t)
+}
+
+func TestService_UpdateManagementVM(t *testing.T) {
+	client := interfaces.NewHTTPClientMock()
+
+	req := &ManagementVMUpdateRequest{Name: "updated-mgr", SNMPMode: "DISABLED"}
+	expected := &ManagementVM{ID: 1, Name: "updated-mgr"}
+
+	client.On("PatchJSON", t.Context(), "configuration/v1/management_vm/1/", req, mock.AnythingOfType("*config.ManagementVM")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ManagementVM)
+		*result = *expected
+	})
+
+	service := New(client)
+	result, err := service.UpdateManagementVM(t.Context(), req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	client.AssertExpectations(t)
+}
+
+func TestService_UpdateManagementVM_ExplicitID(t *testing.T) {
+	client := interfaces.NewHTTPClientMock()
+
+	req := &ManagementVMUpdateRequest{Name: "pi2-mgr", SNMPMode: "DISABLED"}
+	expected := &ManagementVM{ID: 3, Name: "pi2-mgr"}
+
+	client.On("PatchJSON", t.Context(), "configuration/v1/management_vm/3/", req, mock.AnythingOfType("*config.ManagementVM")).Return(nil).Run(func(args mock.Arguments) {
+		result := args.Get(3).(*ManagementVM)
+		*result = *expected
+	})
+
+	service := New(client)
+	result, err := service.UpdateManagementVM(t.Context(), req, 3)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	client.AssertExpectations(t)
+}


### PR DESCRIPTION
Support IDs different from 1
management_vm ID was hardcoded to 1, which isn't a problem if the deployment was created and managed only through terraform. However for deployments created outside terraform and imported later, the ID could have a different value. 